### PR TITLE
Add tag mapping and tag existance filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 
 ## Unreleased
 
+- Added rule tags to results to enable grouping and sorting [#14](https://github.com/BernieWhite/PSRule/issues/14)
+- Added support to check for rule tag existence. Use `*` for tag value on `-Tag` parameter with `Invoke-PSRule` and `Get-PSRule`
+
 ## v0.1.0-B181212
 
 - Initial pre-release

--- a/docs/commands/PSRule/en-US/Get-PSRule.md
+++ b/docs/commands/PSRule/en-US/Get-PSRule.md
@@ -70,6 +70,8 @@ Accept wildcard characters: False
 
 Only get rules with the specified tags set. If this parameter is not specified all rules in search paths will be returned.
 
+When more then one tag is used, all tags must match. Tag names are not case sensitive, tag values are case sensitive. A tag value of `*` may be used to filter rules to any rule with the tag set, regardless of tag value.
+
 ```yaml
 Type: Hashtable
 Parameter Sets: (All)

--- a/docs/commands/PSRule/en-US/Invoke-PSRule.md
+++ b/docs/commands/PSRule/en-US/Invoke-PSRule.md
@@ -103,6 +103,8 @@ Accept wildcard characters: False
 
 Only evaluate rules with the specified tags set. If this parameter is not specified all rules in search paths will be evaluated.
 
+When more then one tag is used, all tags must match. Tag names are not case sensitive, tag values are case sensitive. A tag value of `*` may be used to filter rules to any rule with the tag set, regardless of tag value.
+
 ```yaml
 Type: Hashtable
 Parameter Sets: (All)
@@ -141,8 +143,10 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-### System.Object
+### PSRule.Rules.RuleResult
 
 ## NOTES
 
 ## RELATED LINKS
+
+[Get-PSRule](Get-PSRule.md)

--- a/src/PSRule/Host/HostHelper.cs
+++ b/src/PSRule/Host/HostHelper.cs
@@ -113,7 +113,7 @@ namespace PSRule.Host
 
                 if (ps.HadErrors)
                 {
-                    throw new System.Exception(ps.Streams.Error[0].Exception.Message, ps.Streams.Error[0].Exception);
+                    throw new Exception(ps.Streams.Error[0].Exception.Message, ps.Streams.Error[0].Exception);
                 }
 
                 foreach (var ir in invokeResults)
@@ -140,7 +140,8 @@ namespace PSRule.Host
                 var result = new RuleResult(block.Id)
                 {
                     TargetObject = inputObject,
-                    TargetName = BindName(inputObject)
+                    TargetName = BindName(inputObject),
+                    Tag = block.Tag?.ToHashtable()
                 };
 
                 LanguageContext._Rule = result;

--- a/src/PSRule/Rules/RuleResult.cs
+++ b/src/PSRule/Rules/RuleResult.cs
@@ -1,4 +1,5 @@
-﻿using System.Management.Automation;
+﻿using System.Collections;
+using System.Management.Automation;
 
 namespace PSRule.Rules
 {
@@ -10,16 +11,18 @@ namespace PSRule.Rules
             Status = RuleResultOutcome.None;
         }
 
-        public string RuleName { get; set; }
+        public string RuleName { get; private set; }
 
-        public bool Success { get; set; }
+        public bool Success { get; internal set; }
 
-        public RuleResultOutcome Status { get; set; }
+        public RuleResultOutcome Status { get; internal set; }
 
-        public string Message { get; set; }
+        public string Message { get; internal set; }
 
-        public string TargetName { get; set; }
+        public string TargetName { get; internal set; }
 
         public PSObject TargetObject { get; internal set; }
+
+        public Hashtable Tag { get; internal set; }
     }
 }

--- a/src/PSRule/Rules/TagSet.cs
+++ b/src/PSRule/Rules/TagSet.cs
@@ -1,20 +1,24 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Dynamic;
 
 namespace PSRule.Rules
 {
-    public sealed class TagSet
+    public sealed class TagSet : DynamicObject
     {
+        private readonly IEqualityComparer<string> _Comparer;
         private readonly Dictionary<string, string> _Tag;
 
         public TagSet()
         {
+            _Comparer = StringComparer.Ordinal;
             _Tag = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         }
 
         private TagSet(Dictionary<string, string> tag)
         {
+            _Comparer = StringComparer.Ordinal;
             _Tag = tag;
         }
 
@@ -35,8 +39,12 @@ namespace PSRule.Rules
             {
                 return false;
             }
+            else if (v == "*")
+            {
+                return true;
+            }
 
-            return StringComparer.OrdinalIgnoreCase.Equals(v, _Tag[k]);
+            return _Comparer.Equals(v, _Tag[k]);
         }
 
         public static TagSet FromHashtable(Hashtable hashtable)
@@ -54,6 +62,28 @@ namespace PSRule.Rules
             }
 
             return new TagSet(dictionary);
+        }
+
+        public Hashtable ToHashtable()
+        {
+            return new Hashtable(_Tag, StringComparer.OrdinalIgnoreCase);
+        }
+
+        public bool ContainsKey(string key)
+        {
+            return _Tag.ContainsKey(key);
+        }
+
+        public bool TryGetValue(string key, out string value)
+        {
+            return _Tag.TryGetValue(key, out value);
+        }
+
+        public override bool TryGetMember(GetMemberBinder binder, out object result)
+        {
+            var found = _Tag.TryGetValue(binder.Name, out string value);
+            result = value;
+            return found;
         }
     }
 }

--- a/tests/PSRule/FromFile.Rule.ps1
+++ b/tests/PSRule/FromFile.Rule.ps1
@@ -19,6 +19,31 @@ Rule 'FromFile3' -Tag @{ category = "group1" } {
     # Inconclusive
 }
 
+# Description: Test for tags
+Rule 'WithTag' -Tag @{ severity = 'critical'; feature = 'tag' } {
+    $True;
+}
+
+# Description: Test for tags
+Rule 'WithTag2' -Tag @{ feature = 'tag' } {
+    $True;
+}
+
+# Description: Test for tags
+Rule 'WithTag3' -Tag @{ severity = 'information'; feature = 'tag' } {
+    $True;
+}
+
+# Description: Test for tags
+Rule 'WithTag4' -Tag @{ Severity = 'critical'; feature = 'tag' } {
+    $True;
+}
+
+# Description: Test for tags
+Rule 'WithTag5' -Tag @{ severity = 'Critical'; feature = 'tag' } {
+    $True;
+}
+
 Rule 'WithPreconditionTrue' -If { $True } -Tag @{ category = 'precondition' } {
     $True;
 }


### PR DESCRIPTION
- Added rule tags to results to enable grouping and sorting #14
- Added support to check for rule tag existence. Use `*` for tag value on `-Tag` parameter with `Invoke-PSRule` and `Get-PSRule`

Fixes #14 