### PR TITLE
Fix Invoke-PSRule summary ignores outcome filter #33

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,21 +3,27 @@ name: Bug report
 about: Report errors or unexpected behaviour
 ---
 
-**Describe the bug**
+**Description of the issues**
+
 A clear and concise description of what the bug is.
 
 **To Reproduce**
-Steps to reproduce the behaviour.
+
+Steps to reproduce the issue:
 
 **Expected behaviour**
+
 A clear and concise description of what you expected to happen.
 
 **Error output**
+
 Capture any error messages and or verbose messages with `-Verbose`.
 
 **Module in use and version (please complete the following information):**
- - Module: [e.g. PSRule]
- - Version [e.g. 0.1.0]
+
+- Module: PSRule
+- Version: [e.g. 0.1.0]
 
 **Additional context**
+
 Add any other context about the problem here.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 
 ## Unreleased
 
+- Fix outcome filtering of summary results [#33](https://github.com/BernieWhite/PSRule/issues/33)
+
 ## v0.1.0-B181235
 
 - RuleId and RuleName are now independent. Rules are created with a name, and the RuleId is generated based on rule name and file name

--- a/src/PSRule/Pipeline/InvokeRulePipeline.cs
+++ b/src/PSRule/Pipeline/InvokeRulePipeline.cs
@@ -2,6 +2,7 @@
 using PSRule.Host;
 using PSRule.Rules;
 using System.Collections.Generic;
+using System.Linq;
 using System.Management.Automation;
 
 namespace PSRule.Pipeline
@@ -58,7 +59,13 @@ namespace PSRule.Pipeline
 
         public IEnumerable<RuleSummaryRecord> GetSummary()
         {
-            return _Summary.Values;
+            foreach (var s in _Summary.Values.ToArray())
+            {
+                if (_Outcome == RuleOutcome.All || (s.Outcome & _Outcome) > 0)
+                {
+                    yield return s;
+                }
+            }
         }
 
         private IEnumerable<RuleRecord> ProcessRule(PSObject o)
@@ -101,7 +108,7 @@ namespace PSRule.Pipeline
         private bool ShouldOutput(RuleOutcome outcome)
         {
             return _ResultFormat == ResultFormat.Detail &&
-                (_Outcome == RuleOutcome.All | (outcome & _Outcome) > 0);
+                (_Outcome == RuleOutcome.All || (outcome & _Outcome) > 0);
         }
 
         private void AddToSummary(RuleBlock ruleBlock, string targetName, RuleOutcome outcome)

--- a/tests/PSRule/FromFile.Rule.ps1
+++ b/tests/PSRule/FromFile.Rule.ps1
@@ -19,6 +19,11 @@ Rule 'FromFile3' -Tag @{ category = "group1" } {
     # Inconclusive
 }
 
+# Description: Test rule 4
+Rule 'FromFile4' -Tag @{ category = "group1" } -DependsOn 'FromFile3' {
+    # Inconclusive
+}
+
 # Description: Test for tags
 Rule 'WithTag' -Tag @{ severity = 'critical'; feature = 'tag' } {
     $True;

--- a/tests/PSRule/PSRule.Common.Tests.ps1
+++ b/tests/PSRule/PSRule.Common.Tests.ps1
@@ -141,17 +141,29 @@ Describe 'Invoke-PSRule' {
         }
 
         It 'Returns summary' {
-            $result = $testObject | Invoke-PSRule -Path (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1') -Tag @{ category = 'group1' } -As Summary;
+            $result = $testObject | Invoke-PSRule -Path (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1') -Tag @{ category = 'group1' } -As Summary -Outcome All;
             $result | Should -Not -BeNullOrEmpty;
-            $result.Count | Should -Be 3;
+            $result.Count | Should -Be 4;
             $result | Should -BeOfType PSRule.Rules.RuleSummaryRecord;
-            $result.RuleName | Should -BeIn 'FromFile1', 'FromFile2', 'FromFile3'
+            $result.RuleName | Should -BeIn 'FromFile1', 'FromFile2', 'FromFile3', 'FromFile4'
             $result.Tag.category | Should -BeIn 'group1';
 
             ($result | Where-Object { $_.RuleName -eq 'FromFile1'}).Outcome | Should -Be 'Pass';
             ($result | Where-Object { $_.RuleName -eq 'FromFile1'}).Pass | Should -Be 2;
             ($result | Where-Object { $_.RuleName -eq 'FromFile2'}).Outcome | Should -Be 'Fail';
             ($result | Where-Object { $_.RuleName -eq 'FromFile2'}).Fail | Should -Be 2;
+            ($result | Where-Object { $_.RuleName -eq 'FromFile4'}).Outcome | Should -Be 'None';
+            ($result | Where-Object { $_.RuleName -eq 'FromFile4'}).Pass | Should -Be 0;
+            ($result | Where-Object { $_.RuleName -eq 'FromFile4'}).Fail | Should -Be 0;
+        }
+
+        It 'Returns filtered summary' {
+            $result = $testObject | Invoke-PSRule -Path (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1') -Tag @{ category = 'group1' } -As Summary -Outcome Fail;
+            $result | Should -Not -BeNullOrEmpty;
+            $result.Count | Should -Be 2;
+            $result | Should -BeOfType PSRule.Rules.RuleSummaryRecord;
+            $result.RuleName | Should -BeIn 'FromFile2', 'FromFile3'
+            $result.Tag.category | Should -BeIn 'group1';
         }
     }
 


### PR DESCRIPTION
- Fix outcome filtering of summary results [#33](https://github.com/BernieWhite/PSRule/issues/33)

Fixes #33 