### PR TITLE
Fix issue verbose logging and handling of hashtable keys #35 #36

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,13 +3,17 @@ name: Bug report
 about: Report errors or unexpected behaviour
 ---
 
-**Description of the issues**
+**Description of the issue**
 
 A clear and concise description of what the bug is.
 
 **To Reproduce**
 
 Steps to reproduce the issue:
+
+```powershell
+
+```
 
 **Expected behaviour**
 
@@ -19,10 +23,14 @@ A clear and concise description of what you expected to happen.
 
 Capture any error messages and or verbose messages with `-Verbose`.
 
-**Module in use and version (please complete the following information):**
+```text
+
+```
+
+**Module in use and version:**
 
 - Module: PSRule
-- Version: [e.g. 0.1.0]
+- Version: **[e.g. 0.1.0]**
 
 **Additional context**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 - Fix outcome filtering of summary results [#33](https://github.com/BernieWhite/PSRule/issues/33)
 - Fix target object counter in verbose logging [#35](https://github.com/BernieWhite/PSRule/issues/35)
+- Fix hashtable keys should be handled as fields [#36](https://github.com/BernieWhite/PSRule/issues/36)
 
 ## v0.1.0-B181235
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## Unreleased
 
 - Fix outcome filtering of summary results [#33](https://github.com/BernieWhite/PSRule/issues/33)
+- Fix target object counter in verbose logging [#35](https://github.com/BernieWhite/PSRule/issues/35)
 
 ## v0.1.0-B181235
 

--- a/PSRule.build.ps1
+++ b/PSRule.build.ps1
@@ -233,7 +233,6 @@ task TestModule Pester, PSScriptAnalyzer, {
     }
 
     # Throw an error if pester tests failed
-
     if ($Null -eq $results) {
         throw 'Failed to get Pester test results.';
     }

--- a/src/PSRule/Commands/RuleKeyword.cs
+++ b/src/PSRule/Commands/RuleKeyword.cs
@@ -26,13 +26,13 @@ namespace PSRule.Commands
             }
 
             var comparer = caseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase;
-
-            var type = targetObject.GetType();
+            var baseObject = GetBaseObject(targetObject);
+            var baseType = baseObject.GetType();
 
             // Handle dictionaries and hashtables
-            if (type.IsAssignableFrom(typeof(IDictionary)))
+            if (typeof(IDictionary).IsAssignableFrom(baseType))
             {
-                var dictionary = (IDictionary)targetObject;
+                var dictionary = (IDictionary)baseObject;
 
                 foreach (var k in dictionary.Keys)
                 {
@@ -44,7 +44,7 @@ namespace PSRule.Commands
                 }
             }
             // Handle PSObjects
-            else if (type.IsAssignableFrom(typeof(PSObject)))
+            else if (targetObject is PSObject)
             {
                 var psobject = (PSObject)targetObject;
 
@@ -60,7 +60,7 @@ namespace PSRule.Commands
             // Handle all other CLR types
             else
             {
-                foreach (var p in type.GetProperties())
+                foreach (var p in baseType.GetProperties())
                 {
                     if (comparer.Equals(name, p.Name))
                     {
@@ -71,6 +71,26 @@ namespace PSRule.Commands
             }
 
             return false;
+        }
+
+        protected object GetBaseObject(object value)
+        {
+            if (value == null)
+            {
+                return null;
+            }
+
+            if (value is PSObject)
+            {
+                var baseObject = ((PSObject)value).BaseObject;
+
+                if (baseObject != null)
+                {
+                    return baseObject;
+                }
+            }
+
+            return value;
         }
     }
 }

--- a/src/PSRule/Pipeline/InvokeRulePipeline.cs
+++ b/src/PSRule/Pipeline/InvokeRulePipeline.cs
@@ -28,30 +28,24 @@ namespace PSRule.Pipeline
             _ResultFormat = resultFormat;
         }
 
-        public IEnumerable<RuleRecord> Process(PSObject o)
+        public IEnumerable<RuleRecord> Process(PSObject targetObject)
         {
-            try
-            {
-                return ProcessRule(o);
-            }
-            finally
-            {
-                
-            }
+            _Context.Next();
+            return ProcessRule(targetObject);
         }
 
-        public IEnumerable<RuleRecord> Process(PSObject[] targets)
+        public IEnumerable<RuleRecord> Process(PSObject[] targetObjects)
         {
             var results = new List<RuleRecord>();
 
-            foreach (var target in targets)
+            foreach (var targetObject in targetObjects)
             {
-                foreach (var result in Process(target))
+                _Context.Next();
+
+                foreach (var result in Process(targetObject))
                 {
                     results.Add(result);
                 }
-
-                _Context.Next();
             }
 
             return results;
@@ -68,7 +62,7 @@ namespace PSRule.Pipeline
             }
         }
 
-        private IEnumerable<RuleRecord> ProcessRule(PSObject o)
+        private IEnumerable<RuleRecord> ProcessRule(PSObject targetObject)
         {
             var results = new List<RuleRecord>();
 
@@ -78,7 +72,7 @@ namespace PSRule.Pipeline
 
                 try
                 {
-                    var result = (target.Skipped) ? new RuleRecord(target.Value.RuleId, reason: RuleOutcomeReason.DependencyFail) : HostHelper.InvokeRuleBlock(_Option, target.Value, o);
+                    var result = (target.Skipped) ? new RuleRecord(target.Value.RuleId, reason: RuleOutcomeReason.DependencyFail) : HostHelper.InvokeRuleBlock(_Option, target.Value, targetObject);
 
                     if (result.Outcome == RuleOutcome.Pass)
                     {

--- a/src/PSRule/Pipeline/PipelineContext.cs
+++ b/src/PSRule/Pipeline/PipelineContext.cs
@@ -16,7 +16,7 @@ namespace PSRule.Pipeline
 
         private PipelineContext(ILogger logger)
         {
-            _ObjectNumber = 0;
+            _ObjectNumber = -1;
             _Logger = logger;
         }
 

--- a/tests/PSRule/FromFile.Rule.ps1
+++ b/tests/PSRule/FromFile.Rule.ps1
@@ -113,7 +113,7 @@ Rule 'ExistsTestNegative' -Tag @{ keyword = 'Exists' } {
     Exists 'name' -CaseSensitive
 }
 
-Rule 'WithinTest' {
+Rule 'WithinTest' -Tag @{ keyword = 'Within' } {
     Within 'Title' 'Mr', 'Miss', 'Mrs', 'Ms'
 }
 
@@ -121,12 +121,16 @@ Rule 'WithinTestCaseSensitive' {
     Within 'Title' 'Mr', 'Miss', 'Mrs', 'Ms' -CaseSensitive
 }
 
-Rule 'MatchTest' {
-    Match 'PhoneNumber' '^(\+61|0)([0-9] {0,1}){8}[0-9]$'
+Rule 'MatchTest' -Tag @{ keyword = 'Match' } {
+    Match 'PhoneNumber' '^(\+61|0)([0-9] {0,1}){8}[0-9]$', '^(0{1,3})$'
+}
+
+Rule 'MatchTestCaseSensitive' -Tag @{ keyword = 'Match' } {
+    Match 'Title' '^(Mr|Miss|Mrs|Ms)$' -CaseSensitive
 }
 
 Rule 'TypeOfTest' {
-    TypeOf 'System.Collections.Hashtable'
+    TypeOf 'System.Collections.Hashtable', 'PSRule.Test.OtherType'
 }
 
 Rule 'AllOfTest' {
@@ -158,4 +162,3 @@ Rule 'AnyOfTestNegative' {
         $False
     }
 }
-

--- a/tests/PSRule/PSRule.Common.Tests.ps1
+++ b/tests/PSRule/PSRule.Common.Tests.ps1
@@ -170,7 +170,7 @@ Describe 'Invoke-PSRule' {
     Context 'With constrained language' {
 
         $testObject = [PSCustomObject]@{
-            Name = "TestObject1"
+            Name = 'TestObject1'
             Value = 1
         }
 

--- a/tests/PSRule/PSRule.Hint.Tests.ps1
+++ b/tests/PSRule/PSRule.Hint.Tests.ps1
@@ -18,7 +18,6 @@ Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule) -Force;
 $here = (Resolve-Path $PSScriptRoot).Path;
 
 Describe 'PSRule -- Hint keyword' -Tag 'Hint' {
-
     Context 'Hint' {
         $testObject = [PSCustomObject]@{
             Name = "TestObject1"
@@ -27,8 +26,7 @@ Describe 'PSRule -- Hint keyword' -Tag 'Hint' {
             }
         }
 
-        It 'Return success' {
-
+        It 'Sets result properties' {
             $result = $testObject | Invoke-PSRule -Path (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1') -Name 'HintTest' -Outcome All;
             $result | Should -Not -BeNullOrEmpty;
             $result.RuleName | Should -Be 'HintTest';

--- a/tests/PSRule/PSRule.Match.Tests.ps1
+++ b/tests/PSRule/PSRule.Match.Tests.ps1
@@ -18,17 +18,58 @@ Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule) -Force;
 $here = (Resolve-Path $PSScriptRoot).Path;
 
 Describe 'PSRule -- Match keyword' -Tag 'Match' {
-
     Context 'Match' {
-        $testObject = [PSCustomObject]@{
-            PhoneNumber = '0400 000 000'
+        It 'Evaluates regex' {
+            # Test positive cases
+            $goodObjects = @(
+                [PSCustomObject]@{ PhoneNumber = '0400 000 000' }
+                [PSCustomObject]@{ PhoneNumber = '000' }
+                @{ PhoneNumber = '000' }
+            )
+            $result = $goodObjects | Invoke-PSRule -Path (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1') -Name 'MatchTest';
+            $result | Should -Not -BeNullOrEmpty;
+            $result.Count | Should -Be 3;
+            $result.Outcome | Should -BeIn 'Pass';
+            $result.RuleName | Should -BeIn 'MatchTest';
+
+            # Test negative cases
+            $badObjects = @(
+                [PSCustomObject]@{ PhoneNo = '0400 000 000' }
+                [PSCustomObject]@{ PhoneNumber = '0 000 000' }
+                [PSCustomObject]@{ PhoneNumber = '100' }
+                @{ PhoneNumber = '100' }
+            )
+            $result = $badObjects | Invoke-PSRule -Path (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1') -Name 'MatchTest';
+            $result | Should -Not -BeNullOrEmpty;
+            $result.Count | Should -Be 4;
+            $result.Outcome | Should -BeIn 'Fail';
+            $result.RuleName | Should -BeIn 'MatchTest';
         }
 
-        It 'Return success' {
-            $result = $testObject | Invoke-PSRule -Path (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1') -Name 'MatchTest';
+        It 'Evaluates regex with case sensitivity' {
+            # Test positive cases
+            $goodObjects = @(
+                [PSCustomObject]@{ Title = 'Mr' }
+                [PSCustomObject]@{ tiTle = 'Miss' }
+                @{ Title = 'Miss' }
+            )
+            $result = $goodObjects | Invoke-PSRule -Path (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1') -Name 'MatchTestCaseSensitive';
             $result | Should -Not -BeNullOrEmpty;
-            $result.IsSuccess() | Should -Be $True;
-            $result.RuleName | Should -Be 'MatchTest';
+            $result.Count | Should -Be 3;
+            $result.Outcome | Should -BeIn 'Pass';
+            $result.RuleName | Should -BeIn 'MatchTestCaseSensitive';
+
+            # Test negative cases
+            $badObjects = @(
+                [PSCustomObject]@{ Title = 'MR' }
+                [PSCustomObject]@{ tiTle = 'miss' }
+                @{ Title = 'miss' }
+            )
+            $result = $badObjects | Invoke-PSRule -Path (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1') -Name 'MatchTestCaseSensitive';
+            $result | Should -Not -BeNullOrEmpty;
+            $result.Count | Should -Be 3;
+            $result.Outcome | Should -BeIn 'Fail';
+            $result.RuleName | Should -BeIn 'MatchTestCaseSensitive';
         }
     }
 }

--- a/tests/PSRule/PSRule.TypeOf.Tests.ps1
+++ b/tests/PSRule/PSRule.TypeOf.Tests.ps1
@@ -18,17 +18,29 @@ Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule) -Force;
 $here = (Resolve-Path $PSScriptRoot).Path;
 
 Describe 'PSRule -- TypeOf keyword' -Tag 'TypeOf' {
-
     Context 'TypeOf' {
-        $testObject = @{
-            Key = 'Value'
-        }
-
-        It 'Return success' {
+        It 'Matches type names' {
+            $hashTableObject = @{ Key = 'Value' }
+            $hashTableObjectWithName1 = @{ Key = 'Value' }; $hashTableObjectWithName1.PSObject.TypeNames.Insert(0, 'AdditionalTypeName');
+            $hashTableObjectWithName2 = @{ Key = 'Value' }; $hashTableObjectWithName2.PSObject.TypeNames.Add('AdditionalTypeName');
+            $customObjectWithName = [PSCustomObject]@{ Key = 'Value' }; $customObjectWithName.PSObject.TypeNames.Add('PSRule.Test.OtherType');
+            $testObject = @($hashTableObject, $hashTableObjectWithName1, $hashTableObjectWithName2, $customObjectWithName);
 
             $result = $testObject | Invoke-PSRule -Path (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1') -Name 'TypeOfTest';
             $result | Should -Not -BeNullOrEmpty;
-            $result.IsSuccess() | Should -Be $True;
+            $result.Count | Should -Be 4;
+            $result.IsSuccess() | Should -BeIn $True;
+            $result.RuleName | Should -BeIn 'TypeOfTest';
+        }
+
+        It 'Does not match type names' {
+            $testObject = [PSCustomObject]@{
+                Key = 'Value'
+            }
+
+            $result = $testObject | Invoke-PSRule -Path (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1') -Name 'TypeOfTest';
+            $result | Should -Not -BeNullOrEmpty;
+            $result.IsSuccess() | Should -Be $False;
             $result.RuleName | Should -Be 'TypeOfTest';
         }
     }

--- a/tests/PSRule/PSRule.Within.Tests.ps1
+++ b/tests/PSRule/PSRule.Within.Tests.ps1
@@ -18,35 +18,37 @@ Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule) -Force;
 $here = (Resolve-Path $PSScriptRoot).Path;
 
 Describe 'PSRule -- Within keyword' -Tag 'Within' {
-
     Context 'Within' {
-
         It 'Matches list' {
             $testObject = @(
-                [PSCustomObject]@{ Title = 'mr' },
+                [PSCustomObject]@{ Title = 'mr' }
                 [PSCustomObject]@{ Title = 'unknown' }
+                @{ Title = 'mr' }
             )
 
             $result = $testObject | Invoke-PSRule -Path (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1') -Name 'WithinTest' -Outcome All;
             $result | Should -Not -BeNullOrEmpty;
-            $result.Count | Should -Be 2;
+            $result.Count | Should -Be 3;
             $result.RuleName | Should -BeIn 'WithinTest'
             $result[0].IsSuccess() | Should -Be $True;
             $result[1].IsSuccess() | Should -Be $False;
+            $result[2].IsSuccess() | Should -Be $True;
         }
 
         It 'Matches list with case sensitivity' {
             $testObject = @(
-                [PSCustomObject]@{ Title = 'mr' },
+                [PSCustomObject]@{ Title = 'mr' }
                 [PSCustomObject]@{ Title = 'Mr' }
+                @{ Title = 'Mr' }
             )
 
             $result = $testObject | Invoke-PSRule -Path (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1') -Name 'WithinTestCaseSensitive';
             $result | Should -Not -BeNullOrEmpty;
-            $result.Count | Should -Be 2;
+            $result.Count | Should -Be 3;
             $result.RuleName | Should -BeIn 'WithinTestCaseSensitive'
             $result[0].IsSuccess() | Should -Be $False;
             $result[1].IsSuccess() | Should -Be $True;
+            $result[2].IsSuccess() | Should -Be $True;
         }
     }
 }


### PR DESCRIPTION
- Fix target object counter in verbose logging #35
- Fix hashtable keys should be handled as fields #36
- Improved unit test cases
- Updated GitHub issue report template

Fixes #35 
Fixes #36
