### PR TITLE
Rename Test-PSRule to Test-PSRuleTarget #57

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Fix Get-PSRule generates exception when no .rule.ps1 scripts exist in path [#53](https://github.com/BernieWhite/PSRule/issues/53)
 - Fix LocalizedData.PathNotFound warning when no .rule.ps1 scripts exist in path [#54](https://github.com/BernieWhite/PSRule/issues/54)
 
-## v0.2.0-B19010501 (pre-release)
+## v0.2.0-B190105 (pre-release)
 
 - Allow objects to be suppressed by _TargetName_ for individual rules [#13](https://github.com/BernieWhite/PSRule/issues/13)
 - Allow binding of _TargetName_ to custom property [#44](https://github.com/BernieWhite/PSRule/issues/44)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 - Fix Get-PSRule generates exception when no .rule.ps1 scripts exist in path [#53](https://github.com/BernieWhite/PSRule/issues/53)
 - Fix LocalizedData.PathNotFound warning when no .rule.ps1 scripts exist in path [#54](https://github.com/BernieWhite/PSRule/issues/54)
+- **Breaking change** - Renamed `Test-PSRule` cmdlet to `Test-PSRuleTarget` which aligns more closely to the verb-noun naming standard [#57](https://github.com/BernieWhite/PSRule/issues/57)
 
 ## v0.2.0-B190105 (pre-release)
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ The following commands exist in the `PSRule` module:
 - [Invoke-PSRule](docs/commands/PSRule/en-US/Invoke-PSRule.md)
 - [Get-PSRule](docs/commands/PSRule/en-US/Get-PSRule.md)
 - [New-PSRuleOption](docs/commands/PSRule/en-US/New-PSRuleOption.md)
-- [Test-PSRule](docs/commands/PSRule/en-US/Test-PSRule.md)
+- [Test-PSRuleTarget](docs/commands/PSRule/en-US/Test-PSRuleTarget.md)
 
 ### Concepts
 

--- a/docs/commands/PSRule/en-US/Invoke-PSRule.md
+++ b/docs/commands/PSRule/en-US/Invoke-PSRule.md
@@ -253,4 +253,4 @@ When you use the `-As Summary`. Otherwise, it returns a `RuleRecord` object.
 ## RELATED LINKS
 
 [Get-PSRule](Get-PSRule.md)
-[Test-PSRule](Test-PSRule.md)
+[Test-PSRuleTarget](Test-PSRuleTarget.md)

--- a/docs/commands/PSRule/en-US/PSRule.md
+++ b/docs/commands/PSRule/en-US/PSRule.md
@@ -26,6 +26,6 @@ Evaluate pipeline objects against matching rules.
 
 Create options to configure PSRule execution.
 
-### [Test-PSRule](Test-PSRule.md)
+### [Test-PSRuleTarget](Test-PSRuleTarget.md)
 
 Evaluate pipeline objects against matching rules.

--- a/docs/commands/PSRule/en-US/Test-PSRuleTarget.md
+++ b/docs/commands/PSRule/en-US/Test-PSRuleTarget.md
@@ -1,11 +1,11 @@
 ---
 external help file: PSRule-help.xml
 Module Name: PSRule
-online version: https://github.com/BernieWhite/PSRule/blob/master/docs/commands/PSRule/en-US/Test-PSRule.md
+online version: https://github.com/BernieWhite/PSRule/blob/master/docs/commands/PSRule/en-US/Test-PSRuleTarget.md
 schema: 2.0.0
 ---
 
-# Test-PSRule
+# Test-PSRuleTarget
 
 ## SYNOPSIS
 
@@ -14,7 +14,7 @@ Pass or fail pipeline objects against matching rules.
 ## SYNTAX
 
 ```text
-Test-PSRule [[-Path] <String[]>] [-Name <String[]>] [-Tag <Hashtable>] -InputObject <PSObject>
+Test-PSRuleTarget [[-Path] <String[]>] [-Name <String[]>] [-Tag <Hashtable>] -InputObject <PSObject>
  [-Option <PSRuleOption>] [<CommonParameters>]
 ```
 
@@ -36,7 +36,7 @@ PSRule uses the following logic to determine overall pass or fail for an object:
 ### Example 1
 
 ```powershell
-@{ Name = 'Item 1' } | Test-PSRule;
+@{ Name = 'Item 1' } | Test-PSRuleTarget;
 ```
 
 Evaluate a simple hashtable on the pipeline against rules loaded from the current working path.

--- a/src/PSRule/PSRule.psd1
+++ b/src/PSRule/PSRule.psd1
@@ -70,7 +70,7 @@ FormatsToProcess = @('PSRule.Format.ps1xml')
 FunctionsToExport = @(
     'Rule'
     'Invoke-PSRule'
-    'Test-PSRule'
+    'Test-PSRuleTarget'
     'Get-PSRule'
     'New-PSRuleOption'
     'AllOf'

--- a/src/PSRule/PSRule.psm1
+++ b/src/PSRule/PSRule.psm1
@@ -143,7 +143,7 @@ function Invoke-PSRule {
 }
 
 # .ExternalHelp PSRule-Help.xml
-function Test-PSRule {
+function Test-PSRuleTarget {
     [CmdletBinding()]
     [OutputType([System.Boolean])]
     param (
@@ -169,7 +169,7 @@ function Test-PSRule {
     )
 
     begin {
-        Write-Verbose -Message "[Test-PSRule] BEGIN::";
+        Write-Verbose -Message "[Test-PSRuleTarget] BEGIN::";
 
         # Get parameter options, which will override options from other sources
         $optionParams = @{ };
@@ -222,7 +222,7 @@ function Test-PSRule {
         if ($Null -ne $pipeline) {
             $pipeline.Dispose();
         }
-        Write-Verbose -Message "[Test-PSRule] END::";
+        Write-Verbose -Message "[Test-PSRuleTarget] END::";
     }
 }
 
@@ -594,6 +594,6 @@ InitEditorServices;
 # Export module
 #
 
-Export-ModuleMember -Function 'Rule','Invoke-PSRule','Test-PSRule','Get-PSRule','New-PSRuleOption';
+Export-ModuleMember -Function 'Rule','Invoke-PSRule','Test-PSRuleTarget','Get-PSRule','New-PSRuleOption';
 
 # EOM

--- a/tests/PSRule.Tests/PSRule.Common.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Common.Tests.ps1
@@ -325,9 +325,9 @@ Describe 'Invoke-PSRule' {
 
 #endregion Invoke-PSRule
 
-#region Test-PSRule
+#region Test-PSRuleTarget
 
-Describe 'Test-PSRule' {
+Describe 'Test-PSRuleTarget' {
     Context 'With defaults' {
         $testObject = [PSCustomObject]@{
             Name = "TestObject1"
@@ -335,14 +335,14 @@ Describe 'Test-PSRule' {
 
         It 'Returns boolean' {
             # Check passing rule
-            $result = $testObject | Test-PSRule -Path (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1') -Name 'FromFile1';
+            $result = $testObject | Test-PSRuleTarget -Path (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1') -Name 'FromFile1';
             $result | Should -Not -BeNullOrEmpty;
             $result | Should -BeOfType System.Boolean;
             $result | Should -Be $True;
 
             # Check result with one failing rule
             $option = @{ 'Execution.InconclusiveWarning' = $False };
-            $result = $testObject | Test-PSRule -Path (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1') -Name 'FromFile1', 'FromFile2', 'FromFile3' -Option $option;
+            $result = $testObject | Test-PSRuleTarget -Path (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1') -Name 'FromFile1', 'FromFile2', 'FromFile3' -Option $option;
             $result | Should -Not -BeNullOrEmpty;
             $result | Should -BeOfType System.Boolean;
             $result | Should -Be $False;
@@ -350,7 +350,7 @@ Describe 'Test-PSRule' {
 
         It 'Returns warnings on inconclusive' {
             # Check result with an inconculsive rule
-            $result = $testObject | Test-PSRule -Path (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1') -Name 'FromFile3' -WarningVariable outWarnings -WarningAction SilentlyContinue;
+            $result = $testObject | Test-PSRuleTarget -Path (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1') -Name 'FromFile3' -WarningVariable outWarnings -WarningAction SilentlyContinue;
             $result | Should -Not -BeNullOrEmpty;
             $result | Should -BeOfType System.Boolean;
             $result | Should -Be $False;
@@ -359,7 +359,7 @@ Describe 'Test-PSRule' {
 
         It 'Returns warnings on no rules' {
             # Check result with no matching rules
-            $result = $testObject | Test-PSRule -Path (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1') -Name 'NotARule' -WarningVariable outWarnings -WarningAction SilentlyContinue;
+            $result = $testObject | Test-PSRuleTarget -Path (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1') -Name 'NotARule' -WarningVariable outWarnings -WarningAction SilentlyContinue;
             $result | Should -BeNullOrEmpty;
             $outWarnings | Should -Be 'Could not find a matching rule. Please check that Path, Name and Tag parameters are correct.';
         }
@@ -369,7 +369,7 @@ Describe 'Test-PSRule' {
             if (!(Test-Path -Path $emptyPath)) {
                 $Null = New-Item -Path $emptyPath -ItemType Directory -Force;
             }
-            $Null = $testObject | Test-PSRule -Path $emptyPath -WarningVariable outWarnings -WarningAction SilentlyContinue;
+            $Null = $testObject | Test-PSRuleTarget -Path $emptyPath -WarningVariable outWarnings -WarningAction SilentlyContinue;
             $warningMessages = $outwarnings.ToArray();
             $warningMessages.Length | Should -Be 1;
             $warningMessages[0] | Should -BeOfType [System.Management.Automation.WarningRecord];
@@ -378,7 +378,7 @@ Describe 'Test-PSRule' {
 
         It 'Returns warnings on no processed rules' {
             # Check result with no rules matching precondition
-            $result = $testObject | Test-PSRule -Path (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1') -Name 'WithPreconditionFalse' -WarningVariable outWarnings -WarningAction SilentlyContinue;
+            $result = $testObject | Test-PSRuleTarget -Path (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1') -Name 'WithPreconditionFalse' -WarningVariable outWarnings -WarningAction SilentlyContinue;
             $result | Should -Not -BeNullOrEmpty;
             $result | Should -BeOfType System.Boolean;
             $result | Should -Be $True;
@@ -387,7 +387,7 @@ Describe 'Test-PSRule' {
     }
 }
 
-#endregion Test-PSRule
+#endregion Test-PSRuleTarget
 
 #region Get-PSRule
 


### PR DESCRIPTION
## PR Summary

- Renamed `Test-PSRule` cmdlet to `Test-PSRuleTarget` which aligns more closely to the verb-noun naming standard #57

## PR Checklist

- [ ] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/BernieWhite/PSRule/blob/master/CHANGELOG.md) has been updated with change under unreleased section
