### PR TITLE
Added support for nested fields and rule configuration #60 #17 #61

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 
 ## Unreleased
 
+- Added support for nested field names with `Exists`, `Within` and `Match` keywords [#60](https://github.com/BernieWhite/PSRule/issues/60)
+- Added support for rule configuration using baselines [#17](https://github.com/BernieWhite/PSRule/issues/17)
+
 ## v0.2.0-B190113 (pre-release)
 
 - Fix Get-PSRule generates exception when no .rule.ps1 scripts exist in path [#53](https://github.com/BernieWhite/PSRule/issues/53)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 - Added support for nested field names with `Exists`, `Within` and `Match` keywords [#60](https://github.com/BernieWhite/PSRule/issues/60)
 - Added support for rule configuration using baselines [#17](https://github.com/BernieWhite/PSRule/issues/17)
+- Use rule description when hint message not set [#61](https://github.com/BernieWhite/PSRule/issues/61)
 
 ## v0.2.0-B190113 (pre-release)
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ isFruit                             1     1     Fail
 For practical examples of PSRule see:
 
 - [Validate configuration of Azure resources](docs/scenarios/azure-resources/azure-resources.md)
+- [Validate Azure resources tags](docs/scenarios/azure-tags/azure-tags.md)
 
 ## Language reference
 

--- a/README.md
+++ b/README.md
@@ -149,6 +149,9 @@ The following commands exist in the `PSRule` module:
 The following conceptual topics exist in the `PSRule` module:
 
 - [Options](docs/concepts/PSRule/en-US/about_PSRule_Options.md)
+  - [Baseline.RuleName](docs/concepts/PSRule/en-US/about_PSRule_Options.md#baselinerulename)
+  - [Baseline.Exclude](docs/concepts/PSRule/en-US/about_PSRule_Options.md#baselineexclude)
+  - [Baseline.Configuration](docs/concepts/PSRule/en-US/about_PSRule_Options.md#baselineconfiguration)
   - [Binding.TargetName](docs/concepts/PSRule/en-US/about_PSRule_Options.md#targetname-binding)
   - [Execution.LanguageMode](docs/concepts/PSRule/en-US/about_PSRule_Options.md#language-mode)
   - [Execution.InconclusiveWarning](docs/concepts/PSRule/en-US/about_PSRule_Options.md#inconclusive-warning)

--- a/docs/commands/PSRule/en-US/New-PSRuleOption.md
+++ b/docs/commands/PSRule/en-US/New-PSRuleOption.md
@@ -14,8 +14,9 @@ Create options to configure PSRule execution.
 ## SYNTAX
 
 ```text
-New-PSRuleOption [[-Option] <PSRuleOption>] [-SuppressTargetName <SuppressionOption>]
- [-BindTargetName <BindTargetName[]>] [[-Path] <String>] [<CommonParameters>]
+New-PSRuleOption [[-Option] <PSRuleOption>] [-BaselineConfiguration <BaselineConfiguration>]
+ [-SuppressTargetName <SuppressionOption>] [-BindTargetName <BindTargetName[]>] [[-Path] <String>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -63,6 +64,14 @@ $option = New-PSRuleOption -BindTargetName $bindFn;
 
 Creates an options object that uses a custom function to bind the _TargetName_ of an object.
 
+### Example 4
+
+```powershell
+$option = New-PSRuleOption -BaselineConfiguration @{ 'appServiceMinInstanceCount' = 2 };
+```
+
+Create an options object that sets the `appServiceMinInstanceCount` baseline configuration option to `2`.
+
 ## PARAMETERS
 
 ### -Option
@@ -101,7 +110,7 @@ Accept wildcard characters: False
 
 ### -SuppressTargetName
 
-Configures suppression for a list of objects by TargetName. Option also accepts a hashtable to configure rule suppression.
+Configures suppression for a list of objects by TargetName. SuppressTargetName also accepts a hashtable to configure rule suppression.
 
 For more information on PSRule options see about_PSRule_Options.
 
@@ -125,6 +134,24 @@ For more information on PSRule options see about_PSRule_Options.
 
 ```yaml
 Type: BindTargetName[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -BaselineConfiguration
+
+Configures a set of baseline configuration values that can be used in rule definitions instead of using hard coded values. BaselineConfiguration also accepts a hashtable of configuration values as key/ value pairs.
+
+For more information on PSRule options see about_PSRule_Options.
+
+```yaml
+Type: BaselineConfiguration
 Parameter Sets: (All)
 Aliases:
 

--- a/docs/concepts/PSRule/en-US/about_PSRule_Options.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Options.md
@@ -10,6 +10,17 @@ Describes additional options that can be used during rule execution.
 
 PSRule lets you use options when calling `Invoke-PSRule` to change how rules are executed. This topic describes what options are available, when to and how to use them.
 
+The following options are available for use:
+
+- [Baseline.RuleName](#baseline.rulename)
+- [Baseline.Exclude](#baseline.exclude)
+- [Baseline.Configuration](#baseline.configuration)
+- [Binding.TargetName](#targetname-binding)
+- [Execution.LanguageMode](#language-mode)
+- [Execution.InconclusiveWarning](#inconclusive-warning)
+- [Execution.NotProcessedWarning](#not-processed-warning)
+- [Suppression](#rule-suppression)
+
 Options can be used by:
 
 - Using the `-Option` parameter of `Invoke-PSRule` with an object created with `New-PSRuleOption`
@@ -47,6 +58,64 @@ For example:
 Invoke-PSRule -Path . -Option '.\myconfig.yml';
 ```
 
+### Baseline.RuleName
+
+The name of specific rules to evaluate. If this option is not specified all rules in search paths will be evaluated.
+
+This option can be overridden at runtime by using the `-Name` parameter of `Invoke-PSRule`, `Get-PSRule` and `Test-PSRuleTarget`.
+
+This option can be specified using:
+
+```powershell
+# PowerShell: Using the Baseline.RuleName hashtable key
+$option = New-PSRuleOption -Option @{ 'Baseline.RuleName' = 'Rule1','Rule2' };
+```
+
+```yaml
+# YAML: Using the baseline/ruleName property
+baseline:
+  ruleName:
+  - rule1
+  - rule2
+```
+
+### Baseline.Exclude
+
+The name of specific rules to exclude from being evaluated. This will exclude rules specified by `Baseline.RuleName` or discovered from a search path.
+
+This option can be specified using:
+
+```powershell
+# PowerShell: Using the Baseline.Exclude hashtable key
+$option = New-PSRuleOption -Option @{ 'Baseline.Exclude' = 'Rule3','Rule4' };
+```
+
+```yaml
+# YAML: Using the baseline/exclude property
+baseline:
+  exclude:
+  - rule3
+  - rule4
+```
+
+### Baseline.Configuration
+
+Configures a set of baseline configuration values that can be used in rule definitions instead of using hard coded values.
+
+This option can be specified using:
+
+```powershell
+# PowerShell: Using the BaselineConfiguration option with a hashtable
+$option = New-PSRuleOption -BaselineConfiguration @{ appServiceMinInstanceCount = 2 };
+```
+
+```yaml
+# YAML: Using the baseline/configuration property
+baseline:
+  configuration:
+    appServiceMinInstanceCount: 2
+```
+
 ### TargetName binding
 
 When an object is passed from the pipeline, PSRule assigns the object a _TargetName_. _TargetName_ is used in output results to identify one object from another. Many objects could be passed down the pipeline at the same time, so using a _TargetName_ that is meaningful is important. _TargetName_ is also used for advanced features such as rule suppression.
@@ -69,12 +138,12 @@ The value that PSRule uses for _TargetName_ is configurable. PSRule uses the fol
 Custom property names to use for binding can be specified using:
 
 ```powershell
-# PowerShell: Using the Binding.TargetName hash table key
+# PowerShell: Using the Binding.TargetName hashtable key
 $option = New-PSRuleOption -Option @{ 'Binding.TargetName' = 'ResourceName', 'AlternateName' };
 ```
 
 ```yaml
-# psrule.yml: Using the binding/targetName YAML property
+# YAML: Using the binding/targetName property
 binding:
   targetName:
   - ResourceName
@@ -115,12 +184,12 @@ The following language modes are available for use in PSRule:
 This option can be specified using:
 
 ```powershell
-# PowerShell: Using the Execution.LanguageMode hash table key
+# PowerShell: Using the Execution.LanguageMode hashtable key
 $option = New-PSRuleOption -Option @{ 'Execution.LanguageMode' = 'ConstrainedLanguage' };
 ```
 
 ```yaml
-# psrule.yml: Using the execution/languageMode YAML property
+# YAML: Using the execution/languageMode property
 execution:
   languageMode: ConstrainedLanguage
 ```
@@ -143,12 +212,12 @@ Inconclusive results will:
 The inconclusive warning can be disabled by using:
 
 ```powershell
-# PowerShell: Using the Execution.InconclusiveWarning hash table key
+# PowerShell: Using the Execution.InconclusiveWarning hashtable key
 $option = New-PSRuleOption -Option @{ 'Execution.InconclusiveWarning' = $False };
 ```
 
 ```yaml
-# psrule.yml: Using the execution/inconclusiveWarning YAML property
+# YAML: Using the execution/inconclusiveWarning property
 execution:
   inconclusiveWarning: false
 ```
@@ -167,12 +236,12 @@ Not processed objects will:
 The not processed warning can be disabled by using:
 
 ```powershell
-# PowerShell: Using the Execution.NotProcessedWarning hash table key
+# PowerShell: Using the Execution.NotProcessedWarning hashtable key
 $option = New-PSRuleOption -Option @{ 'Execution.NotProcessedWarning' = $False };
 ```
 
 ```yaml
-# psrule.yml: Using the execution/notProcessedWarning YAML property
+# YAML: Using the execution/notProcessedWarning property
 execution:
   notProcessedWarning: false
 ```
@@ -188,12 +257,12 @@ Rule suppression complements pre-filtering and pre-conditions.
 This option can be specified using:
 
 ```powershell
-# PowerShell: Using the SuppressTargetName option with a hash table
+# PowerShell: Using the SuppressTargetName option with a hashtable
 $option = New-PSRuleOption -SuppressTargetName @{ 'storageAccounts.UseHttps' = 'TestObject1', 'TestObject3' };
 ```
 
 ```yaml
-# psrule.yml: Using the suppression YAML property
+# YAML: Using the suppression property
 suppression:
   storageAccounts.UseHttps:
     targetName:
@@ -240,18 +309,30 @@ Rule 'isFruit' -If { $TargetObject.Category -eq 'Produce' } {
 ### Example PSRule.yml
 
 ```yaml
+# Configure baseline
+baseline:
+  ruleName:
+  - rule1
+  - rule2
+  exclude:
+  - rule3
+  - rule4
+  configuration:
+    appServiceMinInstanceCount: 2
+
+# Configure TargetName binding
 binding:
   targetName:
   - ResourceName
   - AlternateName
 
-# Set execution options
+# Configure execution options
 execution:
   languageMode: ConstrainedLanguage
   inconclusiveWarning: false
   notProcessedWarning: false
 
-# Suppress the following target names
+# Configure rule suppression
 suppression:
   storageAccounts.UseHttps:
     targetName:
@@ -264,16 +345,26 @@ suppression:
 ```yaml
 # These are the default options.
 # Only properties that differ from the default values need to be specified.
+
+# Configure baseline
+baseline:
+  ruleName: [ ]
+  exclude: [ ]
+  configuration: { }
+
+# Configure TargetName binding
 binding:
   targetName:
   - TargetName
   - Name
 
+# Configure execution options
 execution:
   languageMode: FullLanguage
   inconclusiveWarning: true
   notProcessedWarning: true
 
+# Configure rule suppression
 suppression: { }
 ```
 

--- a/docs/concepts/PSRule/en-US/about_PSRule_Options.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Options.md
@@ -12,9 +12,9 @@ PSRule lets you use options when calling `Invoke-PSRule` to change how rules are
 
 The following options are available for use:
 
-- [Baseline.RuleName](#baseline.rulename)
-- [Baseline.Exclude](#baseline.exclude)
-- [Baseline.Configuration](#baseline.configuration)
+- [Baseline.RuleName](#baselinerulename)
+- [Baseline.Exclude](#baselineexclude)
+- [Baseline.Configuration](#baselineconfiguration)
 - [Binding.TargetName](#targetname-binding)
 - [Execution.LanguageMode](#language-mode)
 - [Execution.InconclusiveWarning](#inconclusive-warning)

--- a/docs/concepts/PSRule/en-US/about_PSRule_Variables.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Variables.md
@@ -29,11 +29,28 @@ The following section properties are available for public read access:
 - `RuleId` - A unique identifier for the rule.
 - `TargetObject` - The object currently being processed on the pipeline.
 - `TargetName` - The name of the object currently being processed on the pipeline. This property will automatically bind to `TargetName` or `Name` properties of the object if they exist.
+- `Configuration` - Configuration values set by a baseline.
 
 Syntax:
 
 ```powershell
 $Rule
+```
+
+Examples:
+
+```powershell
+# This rule determined if the target object matches the naming convention
+Rule 'resource.NamingConvention' {
+    $Rule.TargetName.ToLower() -ceq $Rule.TargetName
+}
+```
+
+```powershell
+# This rule uses a threshold stored as $Rule.Configuration.appServiceMinInstanceCount
+Rule 'appServicePlan.MinInstanceCount' -If { $TargetObject.ResourceType -eq 'Microsoft.Web/serverfarms' } {
+    $TargetObject.Sku.capacity -ge $Rule.Configuration.appServiceMinInstanceCount
+} -Configure @{ appServiceMinInstanceCount = 2 }
 ```
 
 ### TargetObject
@@ -46,6 +63,15 @@ Syntax:
 
 ```powershell
 $TargetObject
+```
+
+Examples:
+
+```powershell
+# Check that sku capacity is set to at least 2
+Rule 'HasMinInstances' {
+    $TargetObject.Sku.capacity -ge 2
+}
 ```
 
 ## NOTE

--- a/docs/scenarios/azure-resources/azure-resources.md
+++ b/docs/scenarios/azure-resources/azure-resources.md
@@ -30,7 +30,7 @@ In the example below:
 
 - We use `storageAccounts.UseHttps` directly after the `Rule` keyword to name the rule definition. Each rule must be named uniquely.
 - The `# Description: ` comment is used to add additional metadata interpreted by PSRule.
-- One or more conditions are defined with the curly braces `{ }`.
+- One or more conditions are defined within the curly braces `{ }`.
 - The rule definition is saved within a file named `storageAccounts.Rule.ps1`.
 
 ```powershell

--- a/docs/scenarios/azure-tags/PSRule.yaml
+++ b/docs/scenarios/azure-tags/PSRule.yaml
@@ -1,0 +1,8 @@
+
+# Configure business units that are allowed
+baseline:
+  configuration:
+    allowedBusinessUnits:
+    - 'IT Operations'
+    - 'Finance'
+    - 'HR'

--- a/docs/scenarios/azure-tags/azure-tags.md
+++ b/docs/scenarios/azure-tags/azure-tags.md
@@ -1,0 +1,199 @@
+# Azure resource tagging example
+
+This is an example of how PSRule can be used to validate tags on Azure resources to match an internal tagging standards.
+
+In this scenario we will use a JSON file:
+
+- [`resources.json`](resources.json) - An export for the Azure resource properties saved for offline use.
+
+To generate a similar `resources.json` file of your own, the use following command.
+
+```powershell
+# Get all resources using the Az modules. Alternatively use Get-AzureRmResource if using AzureRm modules.
+# This command also requires authentication with Connect-AzAccount or Connect-AzureRmAccount
+Get-AzResource -ExpandProperties | ConvertTo-Json -Depth 10 | Set-Content -path .\resources.json;
+```
+
+For this example we ran this command:
+
+```powershell
+Get-AzResource -ExpandProperties | ConvertTo-Json -Depth 10 | Set-Content -path docs/scenarios/azure-resources/resources.json;
+```
+
+## Define rules
+
+To validate our Azure resources, we need to define some rules. Rules are defined by using the `Rule` keyword in a file ending with the `.Rule.ps1` extension.
+
+Our business rules for Azure resource tagging can be defined with the following dot points:
+
+- Tag names should be easy to read and understand
+- Tag names will use lower-camel/ pascal casing
+- The following mandatory tags will be used:
+  - environment: An operational environment for systems and services. Valid environments are _production_, _testing_ and _development_.
+  - costCentre: A allocation account with financial systems used for charging costs to a business unit. A cost centre is a number with 5 digits, and can't start with a 0.
+
+To start we are going to define an `environmentTag` rule, which will ensure that the _environment_ tag exists and that the value only uses allowed values.
+
+In the example below:
+
+- We use `environmentTag` directly after the `Rule` keyword to name the rule definition. Each rule must be named uniquely.
+- The `# Description: ` comment is used to add additional metadata interpreted by PSRule.
+- One or more conditions are defined within the curly braces `{ }`.
+- The rule definition is saved within a file named `azureTags.Rule.ps1`.
+
+```powershell
+# Description: Has environment tag
+Rule 'environmentTag' {
+    # Rule conditions go here
+}
+```
+
+### Check that tag exists
+
+Conditions can be any valid PowerShell expression that results in a `$True` or `$False`, just like an `If` statement, but without specifically requiring the `If` keyword to be used.
+
+In `resources.json` one of our example storage accounts has the `Tags` property as shown below, this is how Azure Resource Manager stores tags of a resource. We will use this property as the basis of our rule to determine if the resource is tagged and what the tag value is.
+
+```json
+{
+    "Name": "storage",
+    "ResourceName": "storage",
+    "ResourceType": "Microsoft.Storage/storageAccounts",
+    "Tags": {
+        "role": "deployment",
+        "environment": "production"
+    }
+}
+```
+
+PSRule also defines several additional keywords to supplement PowerShell. These additional keywords allow rules to be defined quickly and easier to read.
+
+In the example below:
+
+- We use the `Exists` keyword to check if the _environment_ tag exists.
+- The `-CaseSensitive` switch is also used to ensure that the tag name uses lowercase.
+- The condition will return `$True` or `$False` back to the pipeline, where:
+  - `$True` - the _environment_ tag exists.
+  - `$False` - the _environment_ tag does not exist.
+
+```powershell
+# Description: Has environment tag
+Rule 'environmentTag' {
+    Exists 'Tags.environment' -CaseSensitive
+}
+```
+
+### Tag uses only allowed values
+
+In our scenario, we have three environments that our environment tag could be set to. In the next example we will ensure that only allowed environment values are used.
+
+In the example below:
+
+- We use the `Within` keyword to check if the _environment_ tag uses any of the allowed values.
+- The `-CaseSensitive` switch is also used to ensure that the tag value is only a lowercase environment name.
+- The condition will return `$True` or `$False` back to the pipeline, where:
+  - `$True` - an allowed environment is used.
+  - `$False` - the _environment_ tag does not use one of the allowed values.
+
+```powershell
+# Description: Has environment tag
+Rule 'environmentTag' {
+    Exists 'Tags.environment' -CaseSensitive
+    Within 'Tags.environment' 'production', 'test', 'development' -CaseSensitive
+}
+```
+
+Alternatively, instead of using the `Within` keyword the `-cin` operator could be used. `Within` provides additional verbose logging, however either syntax is valid.
+
+In the example below:
+
+- `$TargetObject` automatic variable is used to get the pipeline object being evaluated.
+- We use the `-cin` operator to check the _environment_ tag only uses allowed values.
+- The `-cin` operator performance a cases sensitive match on _production_, _test_ and _development_.
+- The condition will return `$True` or `$False` back to the pipeline, where:
+  - `$True` - an allowed environment is used.
+  - `$False` - the _environment_ tag does not use one of the allowed values.
+
+```powershell
+# Description: Has environment tag
+Rule 'environmentTag' {
+    Exists 'Tags.environment' -CaseSensitive
+    $TargetObject.Tags.environment -cin 'production', 'test', 'development'
+}
+```
+
+### Tag value matches regular expression
+
+For our second rule `costCentreTag`, the value of the tag must be 5 numbers. We can validate this by using a regular expression.
+
+In the example below:
+
+- We use the `Match` keyword to check if the _costCentre_ tag uses a numeric only value with 5 digits, not starting with 0.
+- The condition will return `$True` or `$False` back to the pipeline, where:
+  - `$True` - the _costCentre_ tag value matches the regular expression.
+  - `$False` - the _costCentre_ tag value does not use match the regular expression.
+
+```powershell
+# Description: Has costCentre tag
+Rule 'costCentreTag' {
+    Exists 'Tags.costCentre' -CaseSensitive
+    Match 'Tags.costCentre' '^([1-9][0-9]{4})$'
+}
+```
+
+An alternative way to write the rule would be to use the `-match` operator instead of the `Match` keyword. Similar to the `Within` keyword, the `Match` keyword provides additional verbose logging that the `-match` operator does not provide.
+
+The the example below:
+
+- `$TargetObject` automatic variable is used to get the pipeline object being evaluated.
+- We use the `-match` operator to check the _costCentre_ tag value matches the regular expression.
+- The condition will return `$True` or `$False` back to the pipeline, where:
+  - `$True` - the _costCentre_ tag value matches the regular expression.
+  - `$False` - the _costCentre_ tag value does not use match the regular expression.
+
+```powershell
+# Description: Has costCentre tag
+Rule 'costCentreTag' {
+    Exists 'Tags.costCentre' -CaseSensitive
+    $TargetObject.Tags.costCentre -match '^([1-9][0-9]{4})$'
+}
+```
+
+## Execute rules
+
+With a rule defined, the next step is to execute it. To execute rules, pipe the target object to `Invoke-PSRule`.
+
+For example:
+
+```powershell
+# Read resources in from file
+$resources = Get-Content -Path .\resources.json | ConvertFrom-Json;
+
+# For each resource
+$resources | Invoke-PSRule;
+```
+
+You will notice, we didn't specify the rule. By default PSRule will look for any `.Rule.ps1` files in the current working path.
+
+`Invoke-PSRule` also supports `-Path`, `-Name` and `-Tag` parameters that can be used to specify the path to look for rules in or filter rules if you want to run a subset of the rules.
+
+For this example we ran these commands:
+
+```powershell
+# Read resources in from file
+$resources = Get-Content -Path docs/scenarios/azure-tags/resources.json | ConvertFrom-Json;
+
+# For each resource
+$resources | Invoke-PSRule -Path docs/scenarios/azure-tags;
+```
+
+Our output looked like this:
+
+```text
+
+```
+
+## More information
+
+- [azureTags.Rule.ps1](azureTags.Rule.ps1) - Example rules for validating Azure resource tagging standard rules.
+- [resources.json](resources.json) - Offline export of Azure resources.

--- a/docs/scenarios/azure-tags/azureTags.Rule.ps1
+++ b/docs/scenarios/azure-tags/azureTags.Rule.ps1
@@ -1,12 +1,25 @@
+#
+# Validation rules for Azure resource tagging standard
+#
 
-# Description: Has environment tag
+if ($Null -eq $Rule.Configuration.allowedBusinessUnits) {
+    Write-Warning -Message 'The allowedBusinessUnits option is not configured';
+}
+
+# Description: Resource must have environment tag
 Rule 'environmentTag' {
     Exists 'Tags.environment' -CaseSensitive
     Within 'Tags.environment' 'production', 'test', 'development' -CaseSensitive
 }
 
-# Description: Has costCentre tag
+# Description: Resource must have costCentre tag
 Rule 'costCentreTag' {
     Exists 'Tags.costCentre' -CaseSensitive
     Match 'Tags.costCentre' '^([1-9][0-9]{4})$'
+}
+
+# Description: Resource must have businessUnit tag
+Rule 'businessUnitTag' {
+    Exists 'Tags.businessUnit' -CaseSensitive
+    Within 'Tags.businessUnit' $Rule.Configuration.allowedBusinessUnits
 }

--- a/docs/scenarios/azure-tags/azureTags.Rule.ps1
+++ b/docs/scenarios/azure-tags/azureTags.Rule.ps1
@@ -1,0 +1,11 @@
+
+# Description: Has environment tag
+Rule 'environmentTag' {
+    Exists 'Tags.environment' -CaseSensitive
+    Within 'Tags.environment' 'production', 'test', 'development' -CaseSensitive
+}
+
+# Description: Has costCentre tag
+Rule 'costCentreTag' {
+    Exists 'Tags.costCentre' -CaseSensitive
+}

--- a/docs/scenarios/azure-tags/azureTags.Rule.ps1
+++ b/docs/scenarios/azure-tags/azureTags.Rule.ps1
@@ -8,4 +8,5 @@ Rule 'environmentTag' {
 # Description: Has costCentre tag
 Rule 'costCentreTag' {
     Exists 'Tags.costCentre' -CaseSensitive
+    Match 'Tags.costCentre' '^([1-9][0-9]{4})$'
 }

--- a/docs/scenarios/azure-tags/resources.json
+++ b/docs/scenarios/azure-tags/resources.json
@@ -1,0 +1,318 @@
+[
+    {
+        "Name": "storage",
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Storage/storageAccounts/storage",
+        "ResourceName": "storage",
+        "ResourceType": "Microsoft.Storage/storageAccounts",
+        "Kind": "Storage",
+        "ResourceGroupName": "test-rg",
+        "Location": "eastus2",
+        "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+        "Tags": {
+            "role": "deployment",
+            "environment": "production"
+        },
+        "Properties": {
+            "networkAcls": {
+                "bypass": "AzureServices",
+                "virtualNetworkRules": [],
+                "ipRules": [],
+                "defaultAction": "Allow"
+            },
+            "supportsHttpsTrafficOnly": false,
+            "encryption": {
+                "services": {
+                    "file": {
+                        "enabled": true
+                    },
+                    "blob": {
+                        "enabled": true
+                    }
+                },
+                "keySource": "Microsoft.Storage"
+            },
+            "primaryEndpoints": {
+                "blob": "https://storage.blob.core.windows.net/",
+                "queue": "https://storage.queue.core.windows.net/",
+                "table": "https://storage.table.core.windows.net/",
+                "file": "https://storage.file.core.windows.net/"
+            },
+            "primaryLocation": "eastus2",
+            "statusOfPrimary": "available"
+        },
+        "Sku": {
+            "name": "Standard_LRS",
+            "tier": "Standard"
+        }
+    },
+    {
+        "Name": "app-service-plan",
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Web/serverfarms/app-service-plan",
+        "ResourceName": "app-service-plan",
+        "ResourceType": "Microsoft.Web/serverfarms",
+        "Kind": "app",
+        "ResourceGroupName": "test-rg",
+        "Location": "East US 2",
+        "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+        "Tags": {
+            "environment": "production"
+        },
+        "Properties": {
+            "name": "app-service-plan",
+            "workerSize": "Default",
+            "workerSizeId": 0,
+            "workerTierName": null,
+            "numberOfWorkers": 1,
+            "currentWorkerSize": "Default",
+            "currentWorkerSizeId": 0,
+            "currentNumberOfWorkers": 1,
+            "adminSiteName": null,
+            "hostingEnvironment": null,
+            "hostingEnvironmentProfile": null,
+            "maximumNumberOfWorkers": 10,
+            "planName": "VirtualDedicatedPlan",
+            "adminRuntimeSiteName": null,
+            "computeMode": "Dedicated",
+            "siteMode": null,
+            "geoRegion": "East US 2",
+            "perSiteScaling": false,
+            "maximumElasticWorkerCount": 0,
+            "numberOfSites": 2,
+            "hostingEnvironmentId": null,
+            "isSpot": false,
+            "spotExpirationTime": null,
+            "freeOfferExpirationTime": null,
+            "tags": {
+                "environment": "production"
+            },
+            "kind": "app",
+            "resourceGroup": "test-rg",
+            "reserved": false,
+            "isXenon": false,
+            "hyperV": false,
+            "targetWorkerCount": 0,
+            "targetWorkerSizeId": 0,
+            "webSiteId": null
+        },
+        "Sku": {
+            "name": "S1",
+            "tier": "Standard",
+            "size": "S1",
+            "family": "S",
+            "capacity": 1
+        }
+    },
+    {
+        "Name": "web-app",
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Web/sites/web-app",
+        "ResourceName": "web-app",
+        "ResourceType": "Microsoft.Web/sites",
+        "Kind": "app",
+        "ResourceGroupName": "test-rg",
+        "Location": "East US 2",
+        "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+        "Properties": {
+            "name": "web-app",
+            "state": "Running",
+            "hostNames": [
+                "web-app.azurewebsites.net"
+            ],
+            "repositorySiteName": "web-app",
+            "owner": null,
+            "usageState": "Normal",
+            "enabled": true,
+            "adminEnabled": true,
+            "enabledHostNames": [
+                "web-app.azurewebsites.net",
+                "web-app.scm.azurewebsites.net"
+            ],
+            "siteProperties": {
+                "metadata": null,
+                "properties": [
+                    {
+                        "name": "LinuxFxVersion",
+                        "value": ""
+                    },
+                    {
+                        "name": "WindowsFxVersion",
+                        "value": null
+                    }
+                ],
+                "appSettings": null
+            },
+            "availabilityState": "Normal",
+            "sslCertificates": null,
+            "csrs": [],
+            "cers": null,
+            "siteMode": null,
+            "hostNameSslStates": [
+                {
+                    "name": "web-app.azurewebsites.net",
+                    "sslState": "Disabled",
+                    "ipBasedSslResult": null,
+                    "virtualIP": null,
+                    "thumbprint": null,
+                    "toUpdate": null,
+                    "toUpdateIpBasedSsl": null,
+                    "ipBasedSslState": "NotConfigured",
+                    "hostType": "Standard"
+                },
+                {
+                    "name": "web-app.scm.azurewebsites.net",
+                    "sslState": "Disabled",
+                    "ipBasedSslResult": null,
+                    "virtualIP": null,
+                    "thumbprint": null,
+                    "toUpdate": null,
+                    "toUpdateIpBasedSsl": null,
+                    "ipBasedSslState": "NotConfigured",
+                    "hostType": "Repository"
+                }
+            ],
+            "computeMode": null,
+            "serverFarm": null,
+            "serverFarmId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Web/serverfarms/app-service-plan",
+            "reserved": false,
+            "isXenon": false,
+            "hyperV": false,
+            "storageRecoveryDefaultState": "Running",
+            "contentAvailabilityState": "Normal",
+            "runtimeAvailabilityState": "Normal",
+            "siteConfig": null,
+            "trafficManagerHostNames": null,
+            "sku": "Standard",
+            "scmSiteAlsoStopped": false,
+            "targetSwapSlot": null,
+            "hostingEnvironment": null,
+            "hostingEnvironmentProfile": null,
+            "clientAffinityEnabled": false,
+            "clientCertEnabled": false,
+            "hostNamesDisabled": false,
+            "domainVerificationIdentifiers": null,
+            "kind": "app",
+            "containerSize": 0,
+            "dailyMemoryTimeQuota": 0,
+            "suspendedTill": null,
+            "siteDisabledReason": 0,
+            "functionExecutionUnitsCache": null,
+            "maxNumberOfWorkers": null,
+            "cloningInfo": null,
+            "hostingEnvironmentId": null,
+            "tags": null,
+            "resourceGroup": "test-rg",
+            "defaultHostName": "web-app.azurewebsites.net",
+            "slotSwapStatus": {
+                "sourceSlotName": "staging",
+                "destinationSlotName": "Production"
+            },
+            "httpsOnly": false
+        }
+    },
+    {
+        "Name": "web-app/staging",
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Web/sites/web-app/slots/staging",
+        "ResourceName": "web-app/staging",
+        "ResourceType": "Microsoft.Web/sites/slots",
+        "Kind": "app",
+        "ResourceGroupName": "test-rg",
+        "Location": "East US 2",
+        "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+        "Properties": {
+            "name": "web-app(staging)",
+            "state": "Running",
+            "hostNames": [
+                "web-app-staging.azurewebsites.net"
+            ],
+            "repositorySiteName": "web-app",
+            "owner": null,
+            "usageState": "Normal",
+            "enabled": true,
+            "adminEnabled": true,
+            "enabledHostNames": [
+                "web-app-staging.azurewebsites.net",
+                "web-app-staging.scm.azurewebsites.net"
+            ],
+            "siteProperties": {
+                "metadata": null,
+                "properties": [
+                    {
+                        "name": "LinuxFxVersion",
+                        "value": ""
+                    },
+                    {
+                        "name": "WindowsFxVersion",
+                        "value": null
+                    }
+                ],
+                "appSettings": null
+            },
+            "availabilityState": "Normal",
+            "sslCertificates": null,
+            "csrs": [],
+            "cers": null,
+            "siteMode": null,
+            "hostNameSslStates": [
+                {
+                    "name": "web-app-staging.azurewebsites.net",
+                    "sslState": "Disabled",
+                    "ipBasedSslResult": null,
+                    "virtualIP": null,
+                    "thumbprint": null,
+                    "toUpdate": null,
+                    "toUpdateIpBasedSsl": null,
+                    "ipBasedSslState": "NotConfigured",
+                    "hostType": "Standard"
+                },
+                {
+                    "name": "web-app-staging.scm.azurewebsites.net",
+                    "sslState": "Disabled",
+                    "ipBasedSslResult": null,
+                    "virtualIP": null,
+                    "thumbprint": null,
+                    "toUpdate": null,
+                    "toUpdateIpBasedSsl": null,
+                    "ipBasedSslState": "NotConfigured",
+                    "hostType": "Repository"
+                }
+            ],
+            "computeMode": null,
+            "serverFarm": null,
+            "serverFarmId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Web/serverfarms/app-service-plan",
+            "reserved": false,
+            "isXenon": false,
+            "hyperV": false,
+            "storageRecoveryDefaultState": "Running",
+            "contentAvailabilityState": "Normal",
+            "runtimeAvailabilityState": "Normal",
+            "siteConfig": null,
+            "deploymentId": "web-app",
+            "trafficManagerHostNames": null,
+            "sku": "Standard",
+            "scmSiteAlsoStopped": false,
+            "targetSwapSlot": null,
+            "hostingEnvironment": null,
+            "hostingEnvironmentProfile": null,
+            "clientAffinityEnabled": false,
+            "clientCertEnabled": false,
+            "hostNamesDisabled": false,
+            "domainVerificationIdentifiers": null,
+            "kind": "app",
+            "containerSize": 0,
+            "dailyMemoryTimeQuota": 0,
+            "suspendedTill": null,
+            "siteDisabledReason": 0,
+            "functionExecutionUnitsCache": null,
+            "maxNumberOfWorkers": null,
+            "cloningInfo": null,
+            "hostingEnvironmentId": null,
+            "tags": null,
+            "resourceGroup": "test-rg",
+            "defaultHostName": "web-app-staging.azurewebsites.net",
+            "slotSwapStatus": {
+                "sourceSlotName": "staging",
+                "destinationSlotName": "Production"
+            },
+            "httpsOnly": true
+        }
+    }
+]

--- a/docs/scenarios/azure-tags/resources.json
+++ b/docs/scenarios/azure-tags/resources.json
@@ -55,7 +55,9 @@
         "Location": "East US 2",
         "SubscriptionId": "00000000-0000-0000-0000-000000000000",
         "Tags": {
-            "environment": "production"
+            "environment": "production",
+            "costCentre": "12345",
+            "businessUnit": "IT Operations"
         },
         "Properties": {
             "name": "app-service-plan",
@@ -111,6 +113,9 @@
         "ResourceGroupName": "test-rg",
         "Location": "East US 2",
         "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+        "Tags": {
+            "businessUnit": "IT Operations"
+        },
         "Properties": {
             "name": "web-app",
             "state": "Running",
@@ -217,6 +222,9 @@
         "ResourceGroupName": "test-rg",
         "Location": "East US 2",
         "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+        "Tags": {
+            "businessUnit": "IT Operations"
+        },
         "Properties": {
             "name": "web-app(staging)",
             "state": "Running",

--- a/src/PSRule.Benchmark/PSRule.cs
+++ b/src/PSRule.Benchmark/PSRule.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using BenchmarkDotNet.Engines;
 using System.IO;
 using System.Reflection;
+using PSRule.Configuration;
 
 namespace PSRule.Benchmark
 {
@@ -49,33 +50,37 @@ namespace PSRule.Benchmark
 
         private void PrepareGetPipeline()
         {
-            var builder = PipelineBuilder.Get();
+            var option = new PSRuleOption();
+            option.Baseline.RuleName = new string[] { "Benchmark" };
+            var builder = PipelineBuilder.Get().Configure(option);
             builder.Source(new string[] { Path.Combine(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location), "Benchmark.Rule.ps1") });
-            builder.FilterBy(new string[] { "Benchmark" }, null);
             _GetPipeline = builder.Build();
         }
 
         private void PrepareInvokePipeline()
         {
-            var builder = PipelineBuilder.Invoke();
+            var option = new PSRuleOption();
+            option.Baseline.RuleName = new string[] { "Benchmark" };
+            var builder = PipelineBuilder.Invoke().Configure(option);
             builder.Source(new string[] { Path.Combine(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location), "Benchmark.Rule.ps1") });
-            builder.FilterBy(new string[] { "Benchmark" }, null);
             _InvokePipeline = builder.Build();
         }
 
         private void PrepareInvokeIfPipeline()
         {
-            var builder = PipelineBuilder.Invoke();
+            var option = new PSRuleOption();
+            option.Baseline.RuleName = new string[] { "BenchmarkIf" };
+            var builder = PipelineBuilder.Invoke().Configure(option);
             builder.Source(new string[] { Path.Combine(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location), "Benchmark.Rule.ps1") });
-            builder.FilterBy(new string[] { "BenchmarkIf" }, null);
             _InvokeIfPipeline = builder.Build();
         }
 
         private void PrepareInvokeSummaryPipeline()
         {
-            var builder = PipelineBuilder.Invoke();
+            var option = new PSRuleOption();
+            option.Baseline.RuleName = new string[] { "Benchmark" };
+            var builder = PipelineBuilder.Invoke().Configure(option);
             builder.Source(new string[] { Path.Combine(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location), "Benchmark.Rule.ps1") });
-            builder.FilterBy(new string[] { "Benchmark" }, null);
             builder.As(Configuration.ResultFormat.Summary);
             _InvokeSummaryPipeline = builder.Build();
         }

--- a/src/PSRule/Commands/AssertExistsCommand.cs
+++ b/src/PSRule/Commands/AssertExistsCommand.cs
@@ -28,14 +28,14 @@ namespace PSRule.Commands
 
         protected override void ProcessRecord()
         {
-            var inputObject = GetTargetObject();
+            var targetObject = GetTargetObject();
 
             bool expected = !Not;
             bool actual = Not;
 
             for (var i = 0; i < Field.Length && actual != expected; i++)
             {
-                actual = GetField(inputObject, Field[i], CaseSensitive, out object fieldValue);
+                actual = ObjectHelper.GetField(targetObject: targetObject, name: Field[i], caseSensitive: CaseSensitive, value: out object fieldValue);
 
                 if (actual == expected)
                 {

--- a/src/PSRule/Commands/AssertMatchCommand.cs
+++ b/src/PSRule/Commands/AssertMatchCommand.cs
@@ -40,11 +40,11 @@ namespace PSRule.Commands
 
         protected override void ProcessRecord()
         {
-            var inputObject = GetTargetObject();
+            var targetObject = GetTargetObject();
 
             var result = false;
 
-            if (GetField(inputObject, Field, false, out object fieldValue))
+            if (ObjectHelper.GetField(targetObject: targetObject, name: Field, caseSensitive: false, value: out object fieldValue))
             {
                 for (var i = 0; i < _Expressions.Length && !result; i++)
                 {

--- a/src/PSRule/Commands/AssertWithinCommand.cs
+++ b/src/PSRule/Commands/AssertWithinCommand.cs
@@ -33,11 +33,11 @@ namespace PSRule.Commands
 
         protected override void ProcessRecord()
         {
-            var inputObject = GetTargetObject();
+            var targetObject = GetTargetObject();
 
             var result = false;
 
-            if (GetField(inputObject, Field, false, out object fieldValue))
+            if (ObjectHelper.GetField(targetObject: targetObject, name: Field, caseSensitive: false, value: out object fieldValue))
             {
                 foreach (var item in AllowedValue)
                 {

--- a/src/PSRule/Commands/LanguageBlock.cs
+++ b/src/PSRule/Commands/LanguageBlock.cs
@@ -1,6 +1,5 @@
 ﻿using PSRule.Annotations;
 using PSRule.Host;
-using PSRule.Pipeline;
 using PSRule.Rules;
 using System.Collections;
 using System.Management.Automation;

--- a/src/PSRule/Commands/NewRuleDefinitionCommand.cs
+++ b/src/PSRule/Commands/NewRuleDefinitionCommand.cs
@@ -45,6 +45,12 @@ namespace PSRule.Commands
         [Parameter(Mandatory = false)]
         public string[] DependsOn { get; set; }
 
+        /// <summary>
+        /// A set of default configuration values.
+        /// </summary>
+        [Parameter(Mandatory = false)]
+        public Hashtable Configure { get; set; }
+
         protected override void ProcessRecord()
         {
             var metadata = GetMetadata(MyInvocation.ScriptName, MyInvocation.ScriptLineNumber, MyInvocation.OffsetInLine);
@@ -66,7 +72,8 @@ namespace PSRule.Commands
                 description: metadata.Description,
                 condition: ps,
                 tag: tag,
-                dependsOn: RuleHelper.ExpandRuleName(DependsOn, MyInvocation.ScriptName)
+                dependsOn: RuleHelper.ExpandRuleName(DependsOn, MyInvocation.ScriptName),
+                configuration: Configure
             );
 
             WriteObject(block);

--- a/src/PSRule/Commands/ObjectHelper.cs
+++ b/src/PSRule/Commands/ObjectHelper.cs
@@ -1,0 +1,145 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Management.Automation;
+using System.Text;
+
+namespace PSRule.Commands
+{
+    internal static class ObjectHelper
+    {
+        private sealed class NameToken
+        {
+            public string Name;
+
+            public NameToken Next;
+        }
+
+        public static bool GetField(object targetObject, string name, bool caseSensitive, out object value)
+        {
+            var nameToken = GetNameTokens(name);
+
+            var comparer = caseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase;
+
+            return GetField(targetObject: targetObject, token: nameToken, comparer: comparer, value: out value);
+        }
+
+        private static bool GetField(object targetObject, NameToken token, StringComparer comparer, out object value)
+        {
+            var baseObject = GetBaseObject(targetObject);
+            var baseType = baseObject.GetType();
+
+            object field = null;
+            bool foundField = false;
+
+            // Handle dictionaries and hashtables
+            if (typeof(IDictionary).IsAssignableFrom(baseType))
+            {
+                var dictionary = (IDictionary)baseObject;
+
+                foreach (var k in dictionary.Keys)
+                {
+                    if (comparer.Equals(token.Name, k))
+                    {
+                        field = dictionary[k];
+                        foundField = true;
+                    }
+                }
+            }
+            // Handle PSObjects
+            else if (targetObject is PSObject)
+            {
+                var psobject = (PSObject)targetObject;
+
+                foreach (var p in psobject.Properties)
+                {
+                    if (comparer.Equals(token.Name, p.Name))
+                    {
+                        field = p.Value;
+                        foundField = true;
+                    }
+                }
+            }
+            // Handle all other CLR types
+            else
+            {
+                foreach (var p in baseType.GetProperties())
+                {
+                    if (comparer.Equals(token.Name, p.Name))
+                    {
+                        field = p.GetValue(targetObject);
+                        foundField = true;
+                    }
+                }
+
+                if (!foundField)
+                {
+                    foreach (var p in baseType.GetFields())
+                    {
+                        if (comparer.Equals(token.Name, p.Name))
+                        {
+                            field = p.GetValue(targetObject);
+                            foundField = true;
+                        }
+                    }
+                }
+            }
+
+            if (foundField)
+            {
+                if (token.Next == null)
+                {
+                    value = field;
+                    return true;
+                }
+                else
+                {
+                    return GetField(targetObject: field, token: token.Next, comparer: comparer, value: out value);
+                }
+            }
+
+            value = null;
+            return false;
+        }
+
+        private static NameToken GetNameTokens(string name)
+        {
+            var nameParts = name.Split('.');
+            var token = new NameToken();
+            var result = token;
+
+            for (var i = 0; i < nameParts.Length; i++)
+            {
+                token.Name = nameParts[i];
+
+                if (i + 1 < nameParts.Length)
+                {
+                    token.Next = new NameToken();
+                    token = token.Next;
+                }
+            }
+
+            return result;
+        }
+
+        private static object GetBaseObject(object value)
+        {
+            if (value == null)
+            {
+                return null;
+            }
+
+            if (value is PSObject)
+            {
+                var baseObject = ((PSObject)value).BaseObject;
+
+                if (baseObject != null)
+                {
+                    return baseObject;
+                }
+            }
+
+            return value;
+        }
+    }
+}

--- a/src/PSRule/Commands/ObjectHelper.cs
+++ b/src/PSRule/Commands/ObjectHelper.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Management.Automation;
-using System.Text;
 
 namespace PSRule.Commands
 {

--- a/src/PSRule/Configuration/BaselineConfiguration.cs
+++ b/src/PSRule/Configuration/BaselineConfiguration.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Dynamic;
+
+namespace PSRule.Configuration
+{
+    /// <summary>
+    /// A set of configuration values that can be used within rule definitions.
+    /// </summary>
+    public sealed class BaselineConfiguration : DynamicObject, IDictionary<string, object>
+    {
+        private Dictionary<string, object> _Configuration;
+
+        public BaselineConfiguration()
+        {
+            _Configuration = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        internal BaselineConfiguration(IDictionary<string, object> rules)
+        {
+            _Configuration = new Dictionary<string, object>(rules, StringComparer.OrdinalIgnoreCase);
+        }
+
+        public object this[string key]
+        {
+            get => _Configuration[key];
+            set => _Configuration[key] = value;
+        }
+
+        public ICollection<string> Keys => _Configuration.Keys;
+
+        public ICollection<object> Values => _Configuration.Values;
+
+        public int Count => _Configuration.Count;
+
+        public bool IsReadOnly => false;
+
+        public void Add(string key, object value)
+        {
+            _Configuration.Add(key, value);
+        }
+
+        public void Add(KeyValuePair<string, object> item)
+        {
+            Add(item.Key, item.Value);
+        }
+
+        public void Clear()
+        {
+            _Configuration.Clear();
+        }
+
+        public bool Contains(KeyValuePair<string, object> item)
+        {
+            return ((IDictionary<string, object>)_Configuration).Contains(item);
+        }
+
+        public bool ContainsKey(string key)
+        {
+            return _Configuration.ContainsKey(key);
+        }
+
+        public void CopyTo(KeyValuePair<string, object>[] array, int arrayIndex)
+        {
+            ((IDictionary<string, object>)_Configuration).CopyTo(array, arrayIndex);
+        }
+
+        public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
+        {
+            return _Configuration.GetEnumerator();
+        }
+
+        public bool Remove(string key)
+        {
+            return _Configuration.Remove(key);
+        }
+
+        public bool Remove(KeyValuePair<string, object> item)
+        {
+            return ((IDictionary<string, object>)_Configuration).Remove(item);
+        }
+
+        public bool TryGetValue(string key, out object value)
+        {
+            return _Configuration.TryGetValue(key, out value);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        public static implicit operator BaselineConfiguration(Hashtable hashtable)
+        {
+            var option = new BaselineConfiguration();
+
+            foreach (DictionaryEntry entry in hashtable)
+            {
+                option._Configuration.Add(entry.Key.ToString(), entry.Value);
+            }
+
+            return option;
+        }
+
+        public override bool TryGetMember(GetMemberBinder binder, out object result)
+        {
+            var found = _Configuration.TryGetValue(binder.Name, out object value);
+            result = value;
+            return found;
+        }
+    }
+}

--- a/src/PSRule/Configuration/BaselineOption.cs
+++ b/src/PSRule/Configuration/BaselineOption.cs
@@ -1,0 +1,41 @@
+﻿namespace PSRule.Configuration
+{
+    /// <summary>
+    /// Options that specify the rules to evaluate or exclude and their configuration.
+    /// </summary>
+    public sealed class BaselineOption
+    {
+        public BaselineOption()
+        {
+            Configuration = new BaselineConfiguration();
+        }
+
+        public BaselineOption(BaselineOption option)
+        {
+            RuleName = option.RuleName;
+            Exclude = option.Exclude;
+            Configuration = new BaselineConfiguration(option.Configuration);
+        }
+
+        /// <summary>
+        /// Rules to evaluate.
+        /// </summary>
+        /// <remarks>
+        /// When not specified all rules will be evaluated.
+        /// </remarks>
+        public string[] RuleName { get; set; }
+
+        /// <summary>
+        /// Rules to exclude from being evaluate.
+        /// </summary>
+        /// <remarks>
+        /// This option takes precedence over RuleName ig a rule is included in both list.
+        /// </remarks>
+        public string[] Exclude { get; set; }
+
+        /// <summary>
+        /// A set of configuration values that can be used within rule definitions.
+        /// </summary>
+        public BaselineConfiguration Configuration { get; set; }
+    }
+}

--- a/src/PSRule/Configuration/PSRuleOption.cs
+++ b/src/PSRule/Configuration/PSRuleOption.cs
@@ -26,6 +26,7 @@ namespace PSRule.Configuration
         public PSRuleOption()
         {
             // Set defaults
+            Baseline = new BaselineOption();
             Binding = new BindingOption();
             Suppression = new SuppressionOption();
             Execution = new ExecutionOption();
@@ -35,6 +36,7 @@ namespace PSRule.Configuration
         public PSRuleOption(PSRuleOption option)
         {
             // Set from existing option instance
+            Baseline = new BaselineOption(option.Baseline);
             Binding = new BindingOption(option.Binding);
             Suppression = new SuppressionOption(option.Suppression);
             Execution = new ExecutionOption(option.Execution);
@@ -48,6 +50,11 @@ namespace PSRule.Configuration
         /// A callback that is overridden by PowerShell so that the current working path can be retrieved.
         /// </summary>
         public static PathDelegate GetWorkingPath = () => Directory.GetCurrentDirectory();
+
+        /// <summary>
+        /// Options that specify the rules to evaluate or exclude and their configuration.
+        /// </summary>
+        public BaselineOption Baseline { get; set; }
 
         /// <summary>
         /// Options tht affect property binding of TargetName.
@@ -133,6 +140,30 @@ namespace PSRule.Configuration
             // Start loading matching values
 
             object value;
+
+            if (index.TryGetValue("baseline.rulename", out value))
+            {
+                if (value.GetType().IsArray)
+                {
+                    option.Baseline.RuleName = ((object[])value).OfType<string>().ToArray();
+                }
+                else
+                {
+                    option.Baseline.RuleName = new string[] { value.ToString() };
+                }
+            }
+
+            if (index.TryGetValue("baseline.exclude", out value))
+            {
+                if (value.GetType().IsArray)
+                {
+                    option.Baseline.Exclude = ((object[])value).OfType<string>().ToArray();
+                }
+                else
+                {
+                    option.Baseline.Exclude = new string[] { value.ToString() };
+                }
+            }
 
             if (index.TryGetValue("binding.targetname", out value))
             {

--- a/src/PSRule/Host/Host.cs
+++ b/src/PSRule/Host/Host.cs
@@ -10,17 +10,19 @@ namespace PSRule.Host
     /// </summary>
     internal sealed class RuleVariable : PSVariable
     {
+        private readonly RuntimeRuleView _View;
+
         public RuleVariable(string name)
             : base(name, null, ScopedItemOptions.ReadOnly)
         {
-
+            _View = new RuntimeRuleView();
         }
 
         public override object Value
         {
             get
             {
-                return PipelineContext.CurrentThread.RuleRecord;
+                return _View;
             }
         }
     }
@@ -50,7 +52,7 @@ namespace PSRule.Host
         /// <summary>
         /// Define language commands.
         /// </summary>
-        private static SessionStateCmdletEntry[] BuiltInCmdlets = new SessionStateCmdletEntry[]
+        private readonly static SessionStateCmdletEntry[] BuiltInCmdlets = new SessionStateCmdletEntry[]
         {
             new SessionStateCmdletEntry("New-RuleDefinition", typeof(NewRuleDefinitionCommand), null),
             new SessionStateCmdletEntry("Set-PSRuleHint", typeof(SetPSRuleHintCommand), null),
@@ -65,25 +67,17 @@ namespace PSRule.Host
         /// <summary>
         /// Define language aliases.
         /// </summary>
-        private static SessionStateAliasEntry[] BuiltInAliases
+        private readonly static SessionStateAliasEntry[] BuiltInAliases = new SessionStateAliasEntry[]
         {
-            get
-            {
-                const ScopedItemOptions ReadOnly = ScopedItemOptions.ReadOnly;
-
-                return new SessionStateAliasEntry[]
-                {
-                    new SessionStateAliasEntry("rule", "New-RuleDefinition", string.Empty, ReadOnly),
-                    new SessionStateAliasEntry("hint", "Set-PSRuleHint", string.Empty, ReadOnly),
-                    new SessionStateAliasEntry("exists", "Assert-Exists", string.Empty, ReadOnly),
-                    new SessionStateAliasEntry("within", "Assert-Within", string.Empty, ReadOnly),
-                    new SessionStateAliasEntry("match", "Assert-Match", string.Empty, ReadOnly),
-                    new SessionStateAliasEntry("typeof", "Assert-TypeOf", string.Empty, ReadOnly),
-                    new SessionStateAliasEntry("allof", "Assert-AllOf", string.Empty, ReadOnly),
-                    new SessionStateAliasEntry("anyof", "Assert-AnyOf", string.Empty, ReadOnly),
-                };
-            }
-        }
+            new SessionStateAliasEntry("rule", "New-RuleDefinition", string.Empty, ScopedItemOptions.ReadOnly),
+            new SessionStateAliasEntry("hint", "Set-PSRuleHint", string.Empty, ScopedItemOptions.ReadOnly),
+            new SessionStateAliasEntry("exists", "Assert-Exists", string.Empty, ScopedItemOptions.ReadOnly),
+            new SessionStateAliasEntry("within", "Assert-Within", string.Empty, ScopedItemOptions.ReadOnly),
+            new SessionStateAliasEntry("match", "Assert-Match", string.Empty, ScopedItemOptions.ReadOnly),
+            new SessionStateAliasEntry("typeof", "Assert-TypeOf", string.Empty, ScopedItemOptions.ReadOnly),
+            new SessionStateAliasEntry("allof", "Assert-AllOf", string.Empty, ScopedItemOptions.ReadOnly),
+            new SessionStateAliasEntry("anyof", "Assert-AnyOf", string.Empty, ScopedItemOptions.ReadOnly),
+        };
 
         /// <summary>
         /// Create a default session state.

--- a/src/PSRule/Host/HostHelper.cs
+++ b/src/PSRule/Host/HostHelper.cs
@@ -110,7 +110,8 @@ namespace PSRule.Host
 
                     if (ps.HadErrors)
                     {
-                        throw new Exception(ps.Streams.Error[0].Exception.Message, ps.Streams.Error[0].Exception);
+                        // Discovery has errors so skip this file
+                        continue;
                     }
 
                     foreach (var ir in invokeResults)

--- a/src/PSRule/Host/RuntimeRule.cs
+++ b/src/PSRule/Host/RuntimeRule.cs
@@ -19,7 +19,7 @@ namespace PSRule.Host
             }
 
             // Check if value exists in Rule definition defaults
-            if (PipelineContext.CurrentThread.RuleBlock.Configuration == null || !PipelineContext.CurrentThread.RuleBlock.Configuration.ContainsKey(binder.Name))
+            if (PipelineContext.CurrentThread.RuleBlock == null || PipelineContext.CurrentThread.RuleBlock.Configuration == null || !PipelineContext.CurrentThread.RuleBlock.Configuration.ContainsKey(binder.Name))
             {
                 result = null;
                 return false;

--- a/src/PSRule/Host/RuntimeRule.cs
+++ b/src/PSRule/Host/RuntimeRule.cs
@@ -1,0 +1,78 @@
+﻿using PSRule.Pipeline;
+using System.Dynamic;
+using System.Management.Automation;
+
+namespace PSRule.Host
+{
+    /// <summary>
+    /// A set of rule configuration values that are exposed at runtime and automatically failback to defaults when not set in configuration.
+    /// </summary>
+    public sealed class RuntimeRuleConfigurationView : DynamicObject
+    {
+        public override bool TryGetMember(GetMemberBinder binder, out object result)
+        {
+            // Get from baseline configuration
+            if (PipelineContext.CurrentThread.Option.Baseline.Configuration.TryGetValue(binder.Name, out object value))
+            {
+                result = value;
+                return true;
+            }
+
+            // Check if value exists in Rule definition defaults
+            if (PipelineContext.CurrentThread.RuleBlock.Configuration == null || !PipelineContext.CurrentThread.RuleBlock.Configuration.ContainsKey(binder.Name))
+            {
+                result = null;
+                return false;
+            }
+
+            // Get from rule default
+            result = PipelineContext.CurrentThread.RuleBlock.Configuration[binder.Name];
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// A set of rule properties that are exposed at runtime through the $Rule variable.
+    /// </summary>
+    public sealed class RuntimeRuleView
+    {
+        public RuntimeRuleView()
+        {
+            Configuration = new RuntimeRuleConfigurationView();
+        }
+
+        public readonly RuntimeRuleConfigurationView Configuration;
+
+        public string RuleName
+        {
+            get
+            {
+                return PipelineContext.CurrentThread.RuleRecord.RuleName;
+            }
+        }
+
+        public string RuleId
+        {
+            get
+            {
+                return PipelineContext.CurrentThread.RuleRecord.RuleId;
+            }
+        }
+
+        public PSObject TargetObject
+        {
+            get
+            {
+                return PipelineContext.CurrentThread.RuleRecord.TargetObject;
+            }
+        }
+
+        public string TargetName
+        {
+            get
+            {
+                return PipelineContext.CurrentThread.RuleRecord.TargetName;
+            }
+        }
+    }
+}

--- a/src/PSRule/PSRule.psm1
+++ b/src/PSRule/PSRule.psm1
@@ -412,17 +412,24 @@ function Rule {
     param (
         # The name of the rule
         [Parameter(Position = 0, Mandatory = $True)]
-        [String]$RuleId,
+        [String]$Name,
 
         # The body of the rule
         [Parameter(Position = 1, Mandatory = $True)]
         [ScriptBlock]$Body,
 
+        [Parameter(Mandatory = $False)]
+        [Hashtable]$Tag,
+
+        [Parameter(Mandatory = $False)]
+        [ScriptBlock]$If,
+
         # Any dependencies for this rule
         [Parameter(Mandatory = $False)]
         [String[]]$DependsOn,
 
-        [Hashtable]$Tag
+        [Parameter(Mandatory = $False)]
+        [Hashtable]$Configure
     )
 
     begin {
@@ -432,8 +439,6 @@ function Rule {
 }
 
 function AllOf {
-
-
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $True, Position = 0)]
@@ -447,7 +452,6 @@ function AllOf {
 }
 
 function AnyOf {
-
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $True, Position = 0)]
@@ -461,7 +465,6 @@ function AnyOf {
 }
 
 function Exists {
-
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $True, Position = 0)]
@@ -481,7 +484,6 @@ function Exists {
 }
 
 function Match {
-
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $True, Position = 0)]
@@ -501,7 +503,6 @@ function Match {
 }
 
 function Within {
-
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $True, Position = 0)]
@@ -521,7 +522,6 @@ function Within {
 }
 
 function TypeOf {
-
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $True, Position = 0)]

--- a/src/PSRule/PSRule.psm1
+++ b/src/PSRule/PSRule.psm1
@@ -100,8 +100,12 @@ function Invoke-PSRule {
             $Option.Execution.LanguageMode = [PSRule.Configuration.LanguageMode]::ConstrainedLanguage;
         }
 
+        if ($PSBoundParameters.ContainsKey('Name')) {
+            $Option.Baseline.RuleName = $Name;
+        }
+
         $builder = [PSRule.Pipeline.PipelineBuilder]::Invoke().Configure($Option);
-        $builder.FilterBy($Name, $Tag);
+        $builder.FilterBy($Tag);
         $builder.Source($sourceFiles);
         $builder.Limit($Outcome);
 
@@ -197,8 +201,12 @@ function Test-PSRuleTarget {
             $Option.Execution.LanguageMode = [PSRule.Configuration.LanguageMode]::ConstrainedLanguage;
         }
 
+        if ($PSBoundParameters.ContainsKey('Name')) {
+            $Option.Baseline.RuleName = $Name;
+        }
+
         $builder = [PSRule.Pipeline.PipelineBuilder]::Invoke().Configure($Option);
-        $builder.FilterBy($Name, $Tag);
+        $builder.FilterBy($Tag);
         $builder.Source($sourceFiles);
         $builder.UseCommandRuntime($PSCmdlet.CommandRuntime);
         $builder.UseLoggingPreferences($ErrorActionPreference, $WarningPreference, $VerbosePreference, $InformationPreference);
@@ -281,8 +289,12 @@ function Get-PSRule {
             $Option.Execution.LanguageMode = [PSRule.Configuration.LanguageMode]::ConstrainedLanguage;
         }
 
+        if ($PSBoundParameters.ContainsKey('Name')) {
+            $Option.Baseline.RuleName = $Name;
+        }
+
         $builder = [PSRule.Pipeline.PipelineBuilder]::Get().Configure($Option);
-        $builder.FilterBy($Name, $Tag);
+        $builder.FilterBy($Tag);
         $builder.Source($sourceFiles);
         $builder.UseCommandRuntime($PSCmdlet.CommandRuntime);
         $builder.UseLoggingPreferences($ErrorActionPreference, $WarningPreference, $VerbosePreference, $InformationPreference);
@@ -321,6 +333,9 @@ function New-PSRuleOption {
         [PSRule.Configuration.PSRuleOption]$Option,
 
         [Parameter(Mandatory = $False)]
+        [PSRule.Configuration.BaselineConfiguration]$BaselineConfiguration,
+
+        [Parameter(Mandatory = $False)]
         [PSRule.Configuration.SuppressionOption]$SuppressTargetName,
 
         [Parameter(Mandatory = $False)]
@@ -350,6 +365,10 @@ function New-PSRuleOption {
             Write-Verbose -Message "Attempting to read: $Path";
 
             $Option = [PSRule.Configuration.PSRuleOption]::FromFile($Path, $True);
+        }
+
+        if ($PSBoundParameters.ContainsKey('BaselineConfiguration')) {
+            $Option.Baseline.Configuration = $BaselineConfiguration;
         }
 
         if ($PSBoundParameters.ContainsKey('SuppressTargetName')) {

--- a/src/PSRule/Pipeline/GetRulePipelineBuilder.cs
+++ b/src/PSRule/Pipeline/GetRulePipelineBuilder.cs
@@ -12,7 +12,7 @@ namespace PSRule.Pipeline
     {
         private string[] _Path;
         private PSRuleOption _Option;
-        private RuleFilter _Filter;
+        private Hashtable _Tag;
         private PipelineLogger _Logger;
         private bool _LogError;
         private bool _LogWarning;
@@ -25,9 +25,9 @@ namespace PSRule.Pipeline
             _Option = new PSRuleOption();
         }
 
-        public void FilterBy(string[] ruleName, Hashtable tag)
+        public void FilterBy(Hashtable tag)
         {
-            _Filter = new RuleFilter(ruleName, tag);
+            _Tag = tag;
         }
 
         public void Source(string[] path)
@@ -43,6 +43,12 @@ namespace PSRule.Pipeline
             }
 
             _Option.Execution.LanguageMode = option.Execution.LanguageMode ?? ExecutionOption.Default.LanguageMode;
+
+            if (option.Baseline != null)
+            {
+                _Option.Baseline.RuleName = option.Baseline.RuleName;
+                _Option.Baseline.Exclude = option.Baseline.Exclude;
+            }
 
             return this;
         }
@@ -72,8 +78,9 @@ namespace PSRule.Pipeline
 
         public GetRulePipeline Build()
         {
+            var filter = new RuleFilter(ruleName: _Option.Baseline.RuleName, tag: _Tag, exclude: _Option.Baseline.Exclude);
             var context = PipelineContext.New(logger: _Logger, option: _Option, bindTargetName: null, logError: _LogError, logWarning: _LogWarning, logVerbose: _LogVerbose, logInformation: _LogInformation);
-            return new GetRulePipeline(_Option, _Path, _Filter, context: context);
+            return new GetRulePipeline(option: _Option, path: _Path, filter: filter, context: context);
         }
     }
 }

--- a/src/PSRule/Pipeline/InvokeRulePipeline.cs
+++ b/src/PSRule/Pipeline/InvokeRulePipeline.cs
@@ -25,10 +25,10 @@ namespace PSRule.Pipeline
             : base(context, option, path, filter)
         {
             _Outcome = outcome;
-            _RuleGraph = HostHelper.GetRuleBlockGraph(_Option, _Path, _Filter);
+            _RuleGraph = HostHelper.GetRuleBlockGraph(option, _Path, _Filter);
             _Summary = new Dictionary<string, RuleSummaryRecord>();
             _ResultFormat = resultFormat;
-            _SuppressionFilter = new RuleSuppressionFilter(_Option.Suppression);
+            _SuppressionFilter = new RuleSuppressionFilter(option.Suppression);
             RuleCount = _RuleGraph.Count;
 
             if (RuleCount == 0)

--- a/src/PSRule/Pipeline/InvokeRulePipelineBuilder.cs
+++ b/src/PSRule/Pipeline/InvokeRulePipelineBuilder.cs
@@ -61,9 +61,7 @@ namespace PSRule.Pipeline
 
         public void UseCommandRuntime(ICommandRuntime2 commandRuntime)
         {
-            _Logger.OnWriteVerbose = commandRuntime.WriteVerbose;
-            _Logger.OnWriteWarning = commandRuntime.WriteWarning;
-            _Logger.OnWriteError = commandRuntime.WriteError;
+            UseCommandRuntime((ICommandRuntime)commandRuntime);
             _Logger.OnWriteInformation = commandRuntime.WriteInformation;
         }
 

--- a/src/PSRule/Pipeline/PipelineContext.cs
+++ b/src/PSRule/Pipeline/PipelineContext.cs
@@ -350,7 +350,8 @@ namespace PSRule.Pipeline
                 ruleName: ruleBlock.RuleName,
                 targetObject: TargetObject,
                 targetName: TargetName,
-                tag: ruleBlock.Tag
+                tag: ruleBlock.Tag,
+                message: ruleBlock.Description
             );
 
             RuleBlock = ruleBlock;

--- a/src/PSRule/Pipeline/PipelineContext.cs
+++ b/src/PSRule/Pipeline/PipelineContext.cs
@@ -40,6 +40,8 @@ namespace PSRule.Pipeline
         internal RuleRecord RuleRecord;
         internal string TargetName;
         internal PSObject TargetObject;
+        internal RuleBlock RuleBlock;
+        internal PSRuleOption Option;
 
         public HashAlgorithm ObjectHashAlgorithm
         {
@@ -63,6 +65,8 @@ namespace PSRule.Pipeline
             _LogWarning = logWarning;
             _LogVerbose = logVerbose;
             _LogInformation = logInformation;
+
+            Option = option;
 
             _LanguageMode = option.Execution.LanguageMode ?? ExecutionOption.Default.LanguageMode.Value;
 
@@ -349,6 +353,8 @@ namespace PSRule.Pipeline
                 tag: ruleBlock.Tag
             );
 
+            RuleBlock = ruleBlock;
+
             return RuleRecord;
         }
 
@@ -359,6 +365,7 @@ namespace PSRule.Pipeline
         {
             _LogPrefix = null;
             RuleRecord = null;
+            RuleBlock = null;
         }
 
         private string GetLogPrefix()

--- a/src/PSRule/Pipeline/RuleRuntimeException.cs
+++ b/src/PSRule/Pipeline/RuleRuntimeException.cs
@@ -1,0 +1,34 @@
+﻿using System;
+
+namespace PSRule.Pipeline
+{
+    /// <summary>
+    /// A rule exception.
+    /// </summary>
+    public sealed class RuleRuntimeException : PipelineExeception
+    {
+        /// <summary>
+        /// Creates a rule exception.
+        /// </summary>
+        public RuleRuntimeException()
+        {
+        }
+
+        /// <summary>
+        /// Creates a rule exception.
+        /// </summary>
+        /// <param name="message">The detail of the exception.</param>
+        public RuleRuntimeException(string message) : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Creates a rule exception.
+        /// </summary>
+        /// <param name="message">The detail of the exception.</param>
+        /// <param name="innerException">A nested exception that caused the issue.</param>
+        public RuleRuntimeException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/PSRule/Rules/RuleBlock.cs
+++ b/src/PSRule/Rules/RuleBlock.cs
@@ -1,5 +1,6 @@
 ﻿using PSRule.Host;
 using System;
+using System.Collections;
 using System.Diagnostics;
 using System.IO;
 using System.Management.Automation;
@@ -16,7 +17,7 @@ namespace PSRule.Rules
     [DebuggerDisplay("{RuleId} @{SourcePath}")]
     public sealed class RuleBlock : ILanguageBlock, IDependencyTarget, IDisposable
     {
-        public RuleBlock(string sourcePath, string ruleName, string description, PowerShell condition, TagSet tag, string[] dependsOn)
+        public RuleBlock(string sourcePath, string ruleName, string description, PowerShell condition, TagSet tag, string[] dependsOn, Hashtable configuration)
         {
             SourcePath = sourcePath;
             RuleName = ruleName;
@@ -28,6 +29,7 @@ namespace PSRule.Rules
             Condition = condition;
             Tag = tag;
             DependsOn = dependsOn;
+            Configuration = configuration;
         }
 
         /// <summary>
@@ -61,9 +63,17 @@ namespace PSRule.Rules
         public readonly string[] DependsOn;
 
         /// <summary>
-        /// One or more tags assigned to block. Tags are additional metadata used to select rules to execute and identify results.
+        /// Tags assigned to block. Tags are additional metadata used to select rules to execute and identify results.
         /// </summary>
         public readonly TagSet Tag;
+
+        /// <summary>
+        /// Configuration defaults for the rule definition.
+        /// </summary>
+        /// <remarks>
+        /// These defaults are used when the value does not exist in the baseline configuration.
+        /// </remarks>
+        public readonly Hashtable Configuration;
 
         string ILanguageBlock.SourcePath => SourcePath;
 

--- a/src/PSRule/Rules/RuleFilter.cs
+++ b/src/PSRule/Rules/RuleFilter.cs
@@ -10,16 +10,19 @@ namespace PSRule.Rules
     public sealed class RuleFilter
     {
         private HashSet<string> _RequiredRuleName;
+        private HashSet<string> _ExcludedRuleName;
         private Hashtable _RequiredTag;
 
         /// <summary>
         /// Filter rules by id or tag.
         /// </summary>
-        /// <param name="ruleName"></param>
-        /// <param name="tag"></param>
-        public RuleFilter(IEnumerable<string> ruleName, Hashtable tag)
+        /// <param name="ruleName">Only accept these rules by name.</param>
+        /// <param name="tag">Only accept rules that have these tags.</param>
+        /// <param name="exclude">Rule that are always excluded by name.</param>
+        public RuleFilter(IEnumerable<string> ruleName, Hashtable tag, IEnumerable<string> exclude)
         {
             _RequiredRuleName = ruleName == null ? null : new HashSet<string>(ruleName, StringComparer.OrdinalIgnoreCase);
+            _ExcludedRuleName = exclude == null ? null : new HashSet<string>(exclude, StringComparer.OrdinalIgnoreCase);
             _RequiredTag = tag ?? null;
         }
 
@@ -29,6 +32,11 @@ namespace PSRule.Rules
         /// <returns>Return true if rule is matched, otherwise false.</returns>
         public bool Match(string ruleName, TagSet tag)
         {
+            if (_ExcludedRuleName != null && _ExcludedRuleName.Contains(ruleName))
+            {
+                return false;
+            }
+
             if (_RequiredRuleName == null || _RequiredRuleName.Contains(ruleName))
             {
                 if (_RequiredTag == null)

--- a/src/PSRule/Rules/RuleRecord.cs
+++ b/src/PSRule/Rules/RuleRecord.cs
@@ -12,7 +12,7 @@ namespace PSRule.Rules
     [DebuggerDisplay("{RuleId}, Outcome = {Outcome}")]
     public sealed class RuleRecord
     {
-        internal RuleRecord(string ruleId, string ruleName, PSObject targetObject, string targetName, TagSet tag, RuleOutcome outcome = RuleOutcome.None, RuleOutcomeReason reason = RuleOutcomeReason.None)
+        internal RuleRecord(string ruleId, string ruleName, PSObject targetObject, string targetName, TagSet tag, RuleOutcome outcome = RuleOutcome.None, RuleOutcomeReason reason = RuleOutcomeReason.None, string message = null)
         {
             RuleId = ruleId;
             RuleName = ruleName;
@@ -26,6 +26,7 @@ namespace PSRule.Rules
 
             Outcome = outcome;
             OutcomeReason = reason;
+            Message = message;
         }
 
         /// <summary>

--- a/tests/PSRule.Tests/FromFile.Rule.ps1
+++ b/tests/PSRule.Tests/FromFile.Rule.ps1
@@ -119,6 +119,11 @@ Rule 'HintTest' {
     Hint 'This is a message' -TargetName 'HintTarget'
 }
 
+# Description: Test for Hint keyword
+Rule 'HintTestWithDescription' {
+    $True
+}
+
 # Description: Test for Exists keyword
 Rule 'ExistsTest' -Tag @{ keyword = 'Exists' } {
     Exists 'Name'

--- a/tests/PSRule.Tests/FromFile.Rule.ps1
+++ b/tests/PSRule.Tests/FromFile.Rule.ps1
@@ -109,6 +109,11 @@ Rule 'VariableTest' {
     $TargetObject.Name -eq $Rule.TargetName;
 }
 
+Rule 'WithConfiguration' {
+    $Rule.Configuration.Value1 -eq 1
+    $Rule.Configuration.Value2 -eq 2
+} -Configure @{ Value1 = 2; Value2 = 2; }
+
 # Description: Test for Hint keyword
 Rule 'HintTest' {
     Hint 'This is a message' -TargetName 'HintTarget'

--- a/tests/PSRule.Tests/FromFile.Rule.ps1
+++ b/tests/PSRule.Tests/FromFile.Rule.ps1
@@ -118,34 +118,52 @@ Rule 'HintTest' {
 Rule 'ExistsTest' -Tag @{ keyword = 'Exists' } {
     Exists 'Name'
     Exists -Not 'NotName'
+    Exists 'Value.Value1'
+    Exists 'NotName','Value'
 }
 
 # Description: Test for Exists keyword
 Rule 'ExistsTestNegative' -Tag @{ keyword = 'Exists' } {
-    Exists 'NotName'
-    Exists 'name' -CaseSensitive
+    AnyOf {
+        Exists 'NotName'
+        Exists 'NotName1','NotName2'
+        Exists 'name' -CaseSensitive
+        Exists 'NotValue.Value1'
+    }
 }
 
+# Description: Test for Within keyword
 Rule 'WithinTest' -Tag @{ keyword = 'Within' } {
-    Within 'Title' 'Mr', 'Miss', 'Mrs', 'Ms'
+    AnyOf {
+        Within 'Title' 'Mr', 'Miss', 'Mrs', 'Ms'
+        Within 'Value.Title' 'Mr'
+    }
 }
 
+# Description: Test for Within keyword
 Rule 'WithinTestCaseSensitive' {
     Within 'Title' 'Mr', 'Miss', 'Mrs', 'Ms' -CaseSensitive
 }
 
+# Description: Test for Match keyword
 Rule 'MatchTest' -Tag @{ keyword = 'Match' } {
-    Match 'PhoneNumber' '^(\+61|0)([0-9] {0,1}){8}[0-9]$', '^(0{1,3})$'
+    AnyOf {
+        Match 'PhoneNumber' '^(\+61|0)([0-9] {0,1}){8}[0-9]$', '^(0{1,3})$'
+        Match 'Value.PhoneNumber' '^(\+61|0)([0-9] {0,1}){8}[0-9]$'
+    }
 }
 
+# Description: Test for Match keyword
 Rule 'MatchTestCaseSensitive' -Tag @{ keyword = 'Match' } {
     Match 'Title' '^(Mr|Miss|Mrs|Ms)$' -CaseSensitive
 }
 
+# Description: Test for TypeOf keyword
 Rule 'TypeOfTest' {
     TypeOf 'System.Collections.Hashtable', 'PSRule.Test.OtherType'
 }
 
+# Description: Test for AllOf keyword
 Rule 'AllOfTest' {
     AllOf {
         $True
@@ -153,6 +171,7 @@ Rule 'AllOfTest' {
     }
 }
 
+# Description: Test for AllOf keyword
 Rule 'AllOfTestNegative' {
     AllOf {
         $True
@@ -160,6 +179,7 @@ Rule 'AllOfTestNegative' {
     }
 }
 
+# Description: Test for AnyOf keyword
 Rule 'AnyOfTest' {
     AnyOf {
         $True
@@ -168,6 +188,7 @@ Rule 'AnyOfTest' {
     }
 }
 
+# Description: Test for AnyOf keyword
 Rule 'AnyOfTestNegative' {
     AnyOf {
         $False

--- a/tests/PSRule.Tests/FromFile.Rule.ps1
+++ b/tests/PSRule.Tests/FromFile.Rule.ps1
@@ -1,3 +1,6 @@
+#
+# Pester unit test rules
+#
 
 # Description: Test rule 1
 Rule 'FromFile1' -Tag @{ category = "group1"; test = "Test1" } {

--- a/tests/PSRule.Tests/FromFileWithException.Rule.ps1
+++ b/tests/PSRule.Tests/FromFileWithException.Rule.ps1
@@ -1,0 +1,7 @@
+#
+# Pester unit test rules
+#
+
+# Raise an exception
+$notObject = $Null;
+$notObject.ToString();

--- a/tests/PSRule.Tests/FromFileWithLogging.Rule.ps1
+++ b/tests/PSRule.Tests/FromFileWithLogging.Rule.ps1
@@ -1,3 +1,6 @@
+#
+# Pester unit test rules
+#
 
 # Logging in main script
 Write-Information -MessageData 'Script information message';

--- a/tests/PSRule.Tests/ObjectHelperTests.cs
+++ b/tests/PSRule.Tests/ObjectHelperTests.cs
@@ -1,0 +1,35 @@
+﻿using PSRule.Commands;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace PSRule
+{
+    public sealed class ObjectHelperTests
+    {
+        public sealed class TestObject1
+        {
+            public string Name;
+
+            public TestObject2 Value;
+        }
+
+        public sealed class TestObject2
+        {
+            public string Value1;
+        }
+
+        [Fact]
+        public void GetFieldTestPOCO()
+        {
+            var testObject = new TestObject1 { Name = "TestObject1", Value = new TestObject2 { Value1 = "Value1" } };
+
+            ObjectHelper.GetField(targetObject: testObject, name: "Name", caseSensitive: false, value: out object actual1);
+            ObjectHelper.GetField(targetObject: testObject, name: "Value.Value1", caseSensitive: false, value: out object actual2);
+
+            Assert.Equal(expected: testObject.Name, actual: actual1);
+            Assert.Equal(expected: testObject.Value.Value1, actual: actual2);
+        }
+    }
+}

--- a/tests/PSRule.Tests/PSRule.Common.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Common.Tests.ps1
@@ -85,6 +85,11 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
             $informationMessages[1] | Should -Be 'Rule information message';
         }
 
+        It 'Propagates PowerShell exceptions' {
+            $Null = $testObject | Invoke-PSRule -Path (Join-Path -Path $here -ChildPath 'FromFileWithException.Rule.ps1') -ErrorVariable outErrors -ErrorAction SilentlyContinue -WarningAction SilentlyContinue;
+            $outErrors | Should -Be 'You cannot call a method on a null-valued expression.';
+        }
+
         It 'Returns error with bad path' {
             { $testObject | Invoke-PSRule -Path (Join-Path -Path $here -ChildPath 'NotAFile.ps1') } | Should -Throw -ExceptionType System.Management.Automation.ItemNotFoundException;
         }

--- a/tests/PSRule.Tests/PSRule.Common.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Common.Tests.ps1
@@ -27,7 +27,7 @@ $Null = New-Item -Path $outputPath -ItemType Directory -Force;
 
 #region Invoke-PSRule
 
-Describe 'Invoke-PSRule' {
+Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
     Context 'With defaults' {
         $testObject = [PSCustomObject]@{
             Name = "TestObject1"
@@ -159,6 +159,13 @@ Describe 'Invoke-PSRule' {
             $result | Should -BeOfType PSRule.Rules.RuleRecord;
             ($result | Where-Object { $_.TargetName -eq 'TestObject1' }).OutcomeReason | Should -BeIn 'Suppressed';
             ($result | Where-Object { $_.TargetName -eq 'TestObject2' }).OutcomeReason | Should -BeIn 'Processed';
+        }
+
+        It 'Processes configuration' {
+            $option = New-PSRuleOption -BaselineConfiguration @{ Value1 = 1 };
+            $result = $testObject | Invoke-PSRule -Path (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1') -Option $option -Name WithConfiguration;
+            $result | Should -Not -BeNullOrEmpty;
+            $result.IsSuccess() | Should -Be $True;
         }
     }
 
@@ -327,7 +334,7 @@ Describe 'Invoke-PSRule' {
 
 #region Test-PSRuleTarget
 
-Describe 'Test-PSRuleTarget' {
+Describe 'Test-PSRuleTarget' -Tag 'Test-PSRuleTarget','Common' {
     Context 'With defaults' {
         $testObject = [PSCustomObject]@{
             Name = "TestObject1"
@@ -376,7 +383,7 @@ Describe 'Test-PSRuleTarget' {
             $warningMessages[0].Message | Should -Be 'Path not found';
         }
 
-        It 'Returns warnings on no processed rules' {
+        It 'Returns warning when not processed' {
             # Check result with no rules matching precondition
             $result = $testObject | Test-PSRuleTarget -Path (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1') -Name 'WithPreconditionFalse' -WarningVariable outWarnings -WarningAction SilentlyContinue;
             $result | Should -Not -BeNullOrEmpty;
@@ -391,7 +398,7 @@ Describe 'Test-PSRuleTarget' {
 
 #region Get-PSRule
 
-Describe 'Get-PSRule' {
+Describe 'Get-PSRule' -Tag 'Get-PSRule','Common' {
     Context 'Using -Path' {
         It 'Returns rules' {
             # Get a list of rules
@@ -455,8 +462,91 @@ Describe 'Get-PSRule' {
 
 #region New-PSRuleOption
 
-Describe 'New-PSRuleOption' -Tag 'Option' {
-    Context 'Read binding' {
+Describe 'New-PSRuleOption' -Tag 'Option','Common','New-PSRuleOption' {
+    Context 'Read Baseline.RuleName' {
+        It 'from default' {
+            $option = New-PSRuleOption;
+            $option.Baseline.RuleName | Should -Be $Null;
+        }
+
+        It 'from Hashtable' {
+            # With single item
+            $option = New-PSRuleOption -Option @{ 'Baseline.RuleName' = 'rule1' };
+            $option.Baseline.RuleName | Should -BeIn 'rule1';
+
+            # With array
+            $option = New-PSRuleOption -Option @{ 'Baseline.RuleName' = 'rule1', 'rule2' };
+            $option.Baseline.RuleName | Should -BeIn 'rule1', 'rule2';
+        }
+
+        It 'from YAML' {
+            # With single item
+            $option = New-PSRuleOption -Option (Join-Path -Path $here -ChildPath 'PSRule.Tests.yml');
+            $option.Baseline.RuleName | Should -BeIn 'rule1';
+
+            # With array
+            $option = New-PSRuleOption -Option (Join-Path -Path $here -ChildPath 'PSRule.Tests2.yml');
+            $option.Baseline.RuleName | Should -BeIn 'rule1', 'rule2';
+
+            # With flat single item
+            $option = New-PSRuleOption -Option (Join-Path -Path $here -ChildPath 'PSRule.Tests3.yml');
+            $option.Baseline.RuleName | Should -BeIn 'rule1';
+        }
+    }
+
+    Context 'Read Baseline.Exclude' {
+        It 'from default' {
+            $option = New-PSRuleOption;
+            $option.Baseline.Exclude | Should -Be $Null;
+        }
+
+        It 'from Hashtable' {
+            # With single item
+            $option = New-PSRuleOption -Option @{ 'Baseline.Exclude' = 'rule3' };
+            $option.Baseline.Exclude | Should -BeIn 'rule3';
+
+            # With array
+            $option = New-PSRuleOption -Option @{ 'Baseline.Exclude' = 'rule3', 'rule4' };
+            $option.Baseline.Exclude | Should -BeIn 'rule3', 'rule4';
+        }
+
+        It 'from YAML' {
+            # With single item
+            $option = New-PSRuleOption -Option (Join-Path -Path $here -ChildPath 'PSRule.Tests.yml');
+            $option.Baseline.Exclude | Should -BeIn 'rule3';
+
+            # With array
+            $option = New-PSRuleOption -Option (Join-Path -Path $here -ChildPath 'PSRule.Tests2.yml');
+            $option.Baseline.Exclude | Should -BeIn 'rule3', 'rule4';
+
+            # With flat single item
+            $option = New-PSRuleOption -Option (Join-Path -Path $here -ChildPath 'PSRule.Tests3.yml');
+            $option.Baseline.Exclude | Should -BeIn 'rule3';
+        }
+    }
+
+    Context 'Read Baseline.Configuration' {
+        It 'from default' {
+            $option = New-PSRuleOption;
+            $option.Baseline.Configuration.Count | Should -Be 0;
+        }
+
+        It 'from Hashtable' {
+            $option = New-PSRuleOption -BaselineConfiguration @{ 'option1' = 'option'; 'option2' = 2; option3 = 'option3a', 'option3b' };
+            $option.Baseline.Configuration.option1 | Should -BeIn 'option';
+            $option.Baseline.Configuration.option2 | Should -Be 2;
+            $option.Baseline.Configuration.option3 | Should -BeIn 'option3a', 'option3b';
+        }
+
+        It 'from YAML' {
+            $option = New-PSRuleOption -Option (Join-Path -Path $here -ChildPath 'PSRule.Tests.yml');
+            $option.Baseline.Configuration.option1 | Should -Be 'option';
+            $option.Baseline.Configuration.option2 | Should -Be 2;
+            $option.Baseline.Configuration.option3 | Should -BeIn 'option3a', 'option3b';
+        }
+    }
+
+    Context 'Read Binding.TargetName' {
         It 'from default' {
             $option = New-PSRuleOption;
             $option.Binding.TargetName | Should -Be $Null;
@@ -561,7 +651,7 @@ Describe 'New-PSRuleOption' -Tag 'Option' {
 
 #region PSRule variables
 
-Describe 'PSRule variables' -Tag 'Variables' {
+Describe 'PSRule variables' -Tag 'Variables','Common' {
     Context 'PowerShell automatic variables' {
         $testObject = [PSCustomObject]@{
             Name = 'VariableTest'

--- a/tests/PSRule.Tests/PSRule.Exists.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Exists.Tests.ps1
@@ -18,7 +18,6 @@ Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule) -Force;
 $here = (Resolve-Path $PSScriptRoot).Path;
 
 Describe 'PSRule -- Exists keyword' -Tag 'Exists' {
-
     Context 'Exists' {
         $testObject = [PSCustomObject]@{
             Name = "TestObject1"

--- a/tests/PSRule.Tests/PSRule.Hint.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Hint.Tests.ps1
@@ -34,5 +34,13 @@ Describe 'PSRule -- Hint keyword' -Tag 'Hint' {
             $result.TargetName | Should -Be 'HintTarget';
             $result.Message | SHould -Be 'This is a message';
         }
+
+        It 'Uses description' {
+            $option = @{ 'Execution.InconclusiveWarning' = $False };
+            $result = $testObject | Invoke-PSRule -Path (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1') -Option $option -Name 'HintTestWithDescription' -Outcome All;
+            $result | Should -Not -BeNullOrEmpty;
+            $result.RuleName | Should -Be 'HintTestWithDescription';
+            $result.Message | SHould -Be 'Test for Hint keyword';
+        }
     }
 }

--- a/tests/PSRule.Tests/PSRule.Match.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Match.Tests.ps1
@@ -25,10 +25,11 @@ Describe 'PSRule -- Match keyword' -Tag 'Match' {
                 [PSCustomObject]@{ PhoneNumber = '0400 000 000' }
                 [PSCustomObject]@{ PhoneNumber = '000' }
                 @{ PhoneNumber = '000' }
+                @{ Value = @{ PhoneNumber = '0400 000 000' }}
             )
             $result = $goodObjects | Invoke-PSRule -Path (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1') -Name 'MatchTest';
             $result | Should -Not -BeNullOrEmpty;
-            $result.Count | Should -Be 3;
+            $result.Count | Should -Be 4;
             $result.Outcome | Should -BeIn 'Pass';
             $result.RuleName | Should -BeIn 'MatchTest';
 

--- a/tests/PSRule.Tests/PSRule.Tests.yml
+++ b/tests/PSRule.Tests/PSRule.Tests.yml
@@ -1,5 +1,16 @@
 # These are options for unit tests
 
+# Configure baseline
+baseline:
+  ruleName:
+  - rule1
+  exclude:
+  - rule3
+  configuration:
+    option1: option
+    option2: 2
+    option3: [ 'option3a', 'option3b' ]
+
 # Configure TargetName binding
 binding:
   targetName:

--- a/tests/PSRule.Tests/PSRule.Tests2.yml
+++ b/tests/PSRule.Tests/PSRule.Tests2.yml
@@ -1,5 +1,14 @@
 # These are options for unit tests
 
+# Configure baseline
+baseline:
+  ruleName:
+  - rule1
+  - rule2
+  exclude:
+  - rule3
+  - rule4
+
 # Configure TargetName binding
 binding:
   targetName:

--- a/tests/PSRule.Tests/PSRule.Tests3.yml
+++ b/tests/PSRule.Tests/PSRule.Tests3.yml
@@ -1,5 +1,10 @@
 # These are options for unit tests
 
+# Configure baseline
+baseline:
+  ruleName: [ 'rule1' ]
+  exclude: [ 'rule3' ]
+
 # Configure TargetName binding
 binding:
   targetName: [ 'ResourceName' ]

--- a/tests/PSRule.Tests/PSRule.Within.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Within.Tests.ps1
@@ -25,15 +25,18 @@ Describe 'PSRule -- Within keyword' -Tag 'Within' {
                 [PSCustomObject]@{ Title = 'unknown' }
                 @{ Title = 'mr' }
                 @{ Value = @{ Title = 'Mr' } }
+                @{ NotTitle = 'a different property' }
             )
 
             $result = $testObject | Invoke-PSRule -Path (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1') -Name 'WithinTest' -Outcome All;
             $result | Should -Not -BeNullOrEmpty;
-            $result.Count | Should -Be 4;
+            $result.Count | Should -Be 5;
             $result.RuleName | Should -BeIn 'WithinTest'
             $result[0].IsSuccess() | Should -Be $True;
             $result[1].IsSuccess() | Should -Be $False;
             $result[2].IsSuccess() | Should -Be $True;
+            $result[3].IsSuccess() | Should -Be $True;
+            $result[4].IsSuccess() | Should -Be $False;
         }
 
         It 'Matches list with case sensitivity' {

--- a/tests/PSRule.Tests/PSRule.Within.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Within.Tests.ps1
@@ -24,11 +24,12 @@ Describe 'PSRule -- Within keyword' -Tag 'Within' {
                 [PSCustomObject]@{ Title = 'mr' }
                 [PSCustomObject]@{ Title = 'unknown' }
                 @{ Title = 'mr' }
+                @{ Value = @{ Title = 'Mr' } }
             )
 
             $result = $testObject | Invoke-PSRule -Path (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1') -Name 'WithinTest' -Outcome All;
             $result | Should -Not -BeNullOrEmpty;
-            $result.Count | Should -Be 3;
+            $result.Count | Should -Be 4;
             $result.RuleName | Should -BeIn 'WithinTest'
             $result[0].IsSuccess() | Should -Be $True;
             $result[1].IsSuccess() | Should -Be $False;

--- a/tests/PSRule.Tests/PipelineTests.cs
+++ b/tests/PSRule.Tests/PipelineTests.cs
@@ -1,3 +1,4 @@
+using PSRule.Configuration;
 using PSRule.Pipeline;
 using System;
 using System.Collections.Generic;
@@ -28,10 +29,10 @@ namespace PSRule
         public void InvokePipeline()
         {
             var testObject1 = new TestObject { Name = "TestObject1" };
-
-            var builder = PipelineBuilder.Invoke();
+            var option = new PSRuleOption();
+            option.Baseline.RuleName = new string[] { "FromFile1" };
+            var builder = PipelineBuilder.Invoke().Configure(option);
             builder.Source(GetTestSource());
-            builder.FilterBy(new string[] { "FromFile1" }, null);
             var pipeline = builder.Build();
 
             var actual = new List<InvokeResult>();


### PR DESCRIPTION
## PR Summary

- Added support for nested field names with `Exists`, `Within` and `Match` keywords #60
- Added support for rule configuration using baselines #17
- Use rule description when hint message not set #61

Fixes #60 
Fixes #17 
Fixes #61

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/BernieWhite/PSRule/blob/master/CHANGELOG.md) has been updated with change under unreleased section
