### PR TITLE
Add support for keyword pipelining #90

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 
 ## Unreleased
 
+- Added support for pipelining with `Exists`, `Within`, `Match` and `TypeOf` keywords [#90](https://github.com/BernieWhite/PSRule/issues/90)
+
 ## v0.3.0-B190224 (pre-release)
 
 - Export variables to improve authoring experience [#83](https://github.com/BernieWhite/PSRule/issues/83)
@@ -9,7 +11,6 @@
 - Added object type binding and dynamic filtering for rules [#82](https://github.com/BernieWhite/PSRule/issues/82)
 - Added support for case-sensitive binding operations [#87](https://github.com/BernieWhite/PSRule/issues/87)
   - Binding is ignores case by default. Set option `Binding.CaseSensitive` to `true` to enable case-sensitivity.
-- Added support for pipelining with `Exists`, `Within`, `Match` and `TypeOf` keywords [#90](https://github.com/BernieWhite/PSRule/issues/90)
 - **Breaking change** - The `-TargetName` parameter of the `Hint` keyword has been deprecated [#81](https://github.com/BernieWhite/PSRule/issues/81)
   - `-TargetName` parameter not longer sets the pipeline object _TargetName_ and generates a warning instead.
   - The `-TargetName` will be completely removed in **v0.4.0**, at which time using the parameter will generate an error.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added object type binding and dynamic filtering for rules [#82](https://github.com/BernieWhite/PSRule/issues/82)
 - Added support for case-sensitive binding operations [#87](https://github.com/BernieWhite/PSRule/issues/87)
   - Binding is ignores case by default. Set option `Binding.CaseSensitive` to `true` to enable case-sensitivity.
+- Added support for pipelining with `Exists`, `Within`, `Match` and `TypeOf` keywords [#90](https://github.com/BernieWhite/PSRule/issues/90)
 - **Breaking change** - The `-TargetName` parameter of the `Hint` keyword has been deprecated [#81](https://github.com/BernieWhite/PSRule/issues/81)
   - `-TargetName` parameter not longer sets the pipeline object _TargetName_ and generates a warning instead.
   - The `-TargetName` will be completely removed in **v0.4.0**, at which time using the parameter will generate an error.

--- a/src/PSRule/Commands/AssertExistsCommand.cs
+++ b/src/PSRule/Commands/AssertExistsCommand.cs
@@ -27,9 +27,12 @@ namespace PSRule.Commands
         [PSDefaultValue(Value = false)]
         public SwitchParameter Not { get; set; }
 
+        [Parameter(Mandatory = false, ValueFromPipeline = true)]
+        public PSObject InputObject { get; set; }
+
         protected override void ProcessRecord()
         {
-            var targetObject = GetTargetObject();
+            var targetObject = InputObject ?? GetTargetObject();
 
             bool expected = !Not;
             bool actual = Not;

--- a/src/PSRule/Commands/AssertMatchCommand.cs
+++ b/src/PSRule/Commands/AssertMatchCommand.cs
@@ -27,6 +27,9 @@ namespace PSRule.Commands
         [Parameter(Mandatory = false)]
         public SwitchParameter CaseSensitive { get; set; }
 
+        [Parameter(Mandatory = false, ValueFromPipeline = true)]
+        public PSObject InputObject { get; set; }
+
         protected override void BeginProcessing()
         {
             // Setup regex expressions
@@ -41,7 +44,7 @@ namespace PSRule.Commands
 
         protected override void ProcessRecord()
         {
-            var targetObject = GetTargetObject();
+            var targetObject = InputObject ?? GetTargetObject();
 
             var result = false;
 

--- a/src/PSRule/Commands/AssertTypeOfCommand.cs
+++ b/src/PSRule/Commands/AssertTypeOfCommand.cs
@@ -13,9 +13,12 @@ namespace PSRule.Commands
         [Parameter(Mandatory = true, Position = 0)]
         public string[] TypeName { get; set; }
 
+        [Parameter(Mandatory = false, ValueFromPipeline = true)]
+        public PSObject InputObject { get; set; }
+
         protected override void ProcessRecord()
         {
-            var inputObject = GetTargetObject();
+            var inputObject = InputObject ?? GetTargetObject();
 
             var result = false;
 

--- a/src/PSRule/Commands/AssertWithinCommand.cs
+++ b/src/PSRule/Commands/AssertWithinCommand.cs
@@ -27,6 +27,9 @@ namespace PSRule.Commands
         [Parameter(Mandatory = false)]
         public SwitchParameter CaseSensitive { get; set; }
 
+        [Parameter(Mandatory = false, ValueFromPipeline = true)]
+        public PSObject InputObject { get; set; }
+
         protected override void BeginProcessing()
         {
             _Comparer = CaseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase;
@@ -34,7 +37,7 @@ namespace PSRule.Commands
 
         protected override void ProcessRecord()
         {
-            var targetObject = GetTargetObject();
+            var targetObject = InputObject ?? GetTargetObject();
 
             var result = false;
 

--- a/src/PSRule/PSRule.psm1
+++ b/src/PSRule/PSRule.psm1
@@ -560,7 +560,10 @@ function Exists {
         [Switch]$CaseSensitive = $False,
 
         [Parameter(Mandatory = $False)]
-        [Switch]$Not = $False
+        [Switch]$Not = $False,
+
+        [Parameter(Mandatory = $False, ValueFromPipeline = $True)]
+        [PSObject]$InputObject
     )
 
     begin {
@@ -583,7 +586,10 @@ function Match {
         [String[]]$Expression,
 
         [Parameter(Mandatory = $False)]
-        [Switch]$CaseSensitive = $False
+        [Switch]$CaseSensitive = $False,
+
+        [Parameter(Mandatory = $False, ValueFromPipeline = $True)]
+        [PSObject]$InputObject
     )
 
     begin {
@@ -606,7 +612,10 @@ function Within {
         [PSObject[]]$AllowedValue,
 
         [Parameter(Mandatory = $False)]
-        [Switch]$CaseSensitive = $False
+        [Switch]$CaseSensitive = $False,
+
+        [Parameter(Mandatory = $False, ValueFromPipeline = $True)]
+        [PSObject]$InputObject
     )
 
     begin {
@@ -623,7 +632,10 @@ function TypeOf {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $True, Position = 0)]
-        [String[]]$TypeName
+        [String[]]$TypeName,
+
+        [Parameter(Mandatory = $False, ValueFromPipeline = $True)]
+        [PSObject]$InputObject
     )
 
     begin {

--- a/tests/PSRule.Tests/FromFile.Rule.ps1
+++ b/tests/PSRule.Tests/FromFile.Rule.ps1
@@ -150,6 +150,7 @@ Rule 'ExistsTest' -Tag @{ keyword = 'Exists' } {
     Exists -Not 'NotName'
     Exists 'Value.Value1'
     Exists 'NotName','Value'
+    @{ Pipeline = 'Value' } | Exists 'Pipeline'
 }
 
 # Description: Test for Exists keyword
@@ -166,7 +167,7 @@ Rule 'ExistsTestNegative' -Tag @{ keyword = 'Exists' } {
 Rule 'WithinTest' -Tag @{ keyword = 'Within' } {
     AnyOf {
         Within 'Title' 'Mr', 'Miss', 'Mrs', 'Ms'
-        Within 'Value.Title' 'Mr'
+        $TargetObject | Within 'Value.Title' 'Mr'
     }
 }
 
@@ -181,6 +182,9 @@ Rule 'MatchTest' -Tag @{ keyword = 'Match' } {
         Match 'PhoneNumber' '^(\+61|0)([0-9] {0,1}){8}[0-9]$', '^(0{1,3})$'
         Match 'Value.PhoneNumber' '^(\+61|0)([0-9] {0,1}){8}[0-9]$'
     }
+
+    # Test pipelining
+    [PSCustomObject]@{ Key = 'Value' } | Match 'Key' 'Value'
 }
 
 # Description: Test for Match keyword
@@ -191,6 +195,11 @@ Rule 'MatchTestCaseSensitive' -Tag @{ keyword = 'Match' } {
 # Description: Test for TypeOf keyword
 Rule 'TypeOfTest' {
     TypeOf 'System.Collections.Hashtable', 'PSRule.Test.OtherType'
+
+    # Test pipelining
+    $inlineObject = [PSCustomObject]@{ Key = 'Value' }
+    $inlineObject.PSObject.TypeNames.Add('PSRule.Test.OtherOtherType')
+    $inlineObject | TypeOf 'PSRule.Test.OtherOtherType'
 }
 
 # Description: Test for AllOf keyword


### PR DESCRIPTION
## PR Summary

- Added support for pipelining with `Exists`, `Within`, `Match` and `TypeOf` keywords #90

Fixes #90 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/BernieWhite/PSRule/blob/master/CHANGELOG.md) has been updated with change under unreleased section
