### PR TITLE
Fix empty YAML object causes format deserialize to fail #92

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## Unreleased
 
 - Added support for pipelining with `Exists`, `Within`, `Match` and `TypeOf` keywords [#90](https://github.com/BernieWhite/PSRule/issues/90)
+- Fix empty YAML object causes format deserialize to fail [#92](https://github.com/BernieWhite/PSRule/issues/92)
 
 ## v0.3.0-B190224 (pre-release)
 

--- a/src/PSRule/Common/YamlConverters.cs
+++ b/src/PSRule/Common/YamlConverters.cs
@@ -86,6 +86,13 @@ namespace PSRule
 
         public object ReadYaml(IParser parser, Type type)
         {
+            // Handle empty objects
+            if (parser.Accept<Scalar>())
+            {
+                parser.Allow<Scalar>();
+                return null;
+            }
+
             var result = new PSObject();
 
             if (parser.Accept<MappingStart>())

--- a/tests/PSRule.Tests/ObjectFromFile.yaml
+++ b/tests/PSRule.Tests/ObjectFromFile.yaml
@@ -1,5 +1,6 @@
 # An object described in YAML for unit testing
 
+---
 targetName: TestObject1
 spec:
   properties:
@@ -11,3 +12,8 @@ spec:
   properties:
     value2: 2
     kind: Test
+
+---
+# Null object
+
+---


### PR DESCRIPTION
## PR Summary

- Fix empty YAML object causes format deserialize to fail #92

Fixes #92 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/BernieWhite/PSRule/blob/master/CHANGELOG.md) has been updated with change under unreleased section
