### PR TITLE
Add outcome logging to PowerShell streams #97

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,7 +9,7 @@
     "editor.insertSpaces": true,
     "editor.tabSize": 4,
     "yaml.schemas": {
-        "./schemas/PSRule-options-0.3.0.schema.json": [
+        "./schemas/PSRule-options-0.4.0.schema.json": [
             "/tests/PSRule.Tests/PSRule.*.yml",
             "/docs/scenarios/*/PSRule.yaml"
         ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 
 ## Unreleased
 
+- Added support for logging pass or fail outcomes to a data stream such as Error, Warning or Information [#97](https://github.com/BernieWhite/PSRule/issues/97)
+
 ## v0.3.0
 
 What's changed since v0.2.0:

--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ The following conceptual topics exist in the `PSRule` module:
   - [Execution.NotProcessedWarning](docs/concepts/PSRule/en-US/about_PSRule_Options.md#not-processed-warning)
   - [Input.Format](docs/concepts/PSRule/en-US/about_PSRule_Options.md#inputformat)
   - [Input.ObjectPath](docs/concepts/PSRule/en-US/about_PSRule_Options.md#inputobjectpath)
+  - [Logging.RuleFail](docs/concepts/PSRule/en-US/about_PSRule_Options.md#loggingrulefail)
+  - [Logging.RulePass](docs/concepts/PSRule/en-US/about_PSRule_Options.md#loggingrulepass)
   - [Suppression](docs/concepts/PSRule/en-US/about_PSRule_Options.md#rule-suppression)
 - [Variables](docs/concepts/PSRule/en-US/about_PSRule_Variables.md)
   - [$Configuration](docs/concepts/PSRule/en-US/about_PSRule_Variables.md#configuration)
@@ -180,7 +182,7 @@ The following conceptual topics exist in the `PSRule` module:
 
 PSRule uses the following schemas:
 
-- [PSRuleOptions](schemas/PSRule-options-0.3.0.schema.json) - Schema for PSRule YAML configuration file.
+- [PSRuleOptions](schemas/PSRule-options-0.4.0.schema.json) - Schema for PSRule YAML configuration file.
 
 ## Changes and versioning
 

--- a/docs/concepts/PSRule/en-US/about_PSRule_Options.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Options.md
@@ -23,6 +23,8 @@ The following options are available for use:
 - [Execution.NotProcessedWarning](#not-processed-warning)
 - [Input.Format](#inputformat)
 - [Input.ObjectPath](#inputobjectpath)
+- [Logging.RuleFail](#loggingrulefail)
+- [Logging.RulePass](#loggingrulepass)
 - [Suppression](#rule-suppression)
 
 Options can be used by:
@@ -374,6 +376,62 @@ input:
   objectPath: items
 ```
 
+### Logging.RuleFail
+
+When an object fails a rule condition the results are written to output as a structured object marked with the outcome of _Fail_. If the rule executed successfully regardless of outcome no other informational messages are shown by default.
+
+In some circumstances such as a continuous integration (CI) pipeline, it may be preferable to see informational messages or abort the CI process if one or more _Fail_ outcomes are returned.
+
+By settings this option, error, warning or information messages will be generated for each rule _fail_ outcome in addition to structured output. By default, outcomes are not logged to an informational stream (i.e. None).
+
+The following streams available:
+
+- None
+- Error
+- Warning
+- Information
+
+This option can be specified using:
+
+```powershell
+# PowerShell: Using the Logging.RuleFail hashtable key
+$option = New-PSRuleOption -Option @{ 'Logging.RuleFail' = 'Error' };
+```
+
+```yaml
+# YAML: Using the logging/ruleFail property
+logging:
+  ruleFail: Error
+```
+
+### Logging.RulePass
+
+When an object passes a rule condition the results are written to output as a structured object marked with the outcome of _Pass_. If the rule executed successfully regardless of outcome no other informational messages are shown by default.
+
+In some circumstances such as a continuous integration (CI) pipeline, it may be preferable to see informational messages.
+
+By settings this option, error, warning or information messages will be generated for each rule _pass_ outcome in addition to structured output. By default, outcomes are not logged to an informational stream (i.e. None).
+
+The following streams available:
+
+- None
+- Error
+- Warning
+- Information
+
+This option can be specified using:
+
+```powershell
+# PowerShell: Using the Logging.RulePass hashtable key
+$option = New-PSRuleOption -Option @{ 'Logging.RulePass' = 'Information' };
+```
+
+```yaml
+# YAML: Using the logging/rulePass property
+logging:
+  rulePass: Information
+```
+
 ### Rule suppression
 
 In certain circumstances it may be necessary to exclude or suppress rules from processing objects that are in a known failed state.
@@ -473,6 +531,11 @@ input:
   format: Yaml
   objectPath: items
 
+# Configures outcome logging options
+logging:
+  ruleFail: Error
+  rulePass: Information
+
 # Configure rule suppression
 suppression:
   storageAccounts.UseHttps:
@@ -515,6 +578,11 @@ execution:
 input:
   format: None
   objectPath:
+
+# Configures outcome logging options
+logging:
+  ruleFail: None
+  rulePass: None
 
 # Configure rule suppression
 suppression: { }

--- a/schemas/PSRule-options-0.4.0.schema.json
+++ b/schemas/PSRule-options-0.4.0.schema.json
@@ -1,0 +1,299 @@
+{
+    "title": "PSRule options",
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "oneOf": [
+        {
+            "$ref": "#/definitions/options-v0.4.0"
+        },
+        {
+            "$ref": "#/definitions/options-v0.3.0"
+        },
+        {
+            "$ref": "#/definitions/options-v0.2.0"
+        }
+    ],
+    "definitions": {
+        "baseline-v0.2.0": {
+            "type": "object",
+            "description": "Options that include/ exclude and configure rules.",
+            "properties": {
+                "ruleName": {
+                    "type": "array",
+                    "description": "Optionally filter rules by name.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "uniqueItems": true
+                },
+                "exclude": {
+                    "type": "array",
+                    "description": "Specifies rules to exclude by name.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "uniqueItems": true
+                },
+                "configuration": {
+                    "type": "object",
+                    "description": "A set of key/ value configuration options for rules."
+                }
+            },
+            "additionalProperties": false
+        },
+        "binding-v0.2.0": {
+            "type": "object",
+            "description": "Configure property/ object binding options.",
+            "properties": {
+                "targetName": {
+                    "type": "array",
+                    "description": "Specifies one or more property names to bind TargetName to.",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "additionalProperties": false
+        },
+        "binding-v0.3.0": {
+            "type": "object",
+            "description": "Configure property/ object binding options.",
+            "properties": {
+                "ignoreCase": {
+                    "type": "boolean",
+                    "description": "Determines if custom binding uses ignores case when matching properties.",
+                    "default": true
+                },
+                "targetName": {
+                    "type": "array",
+                    "description": "Specifies one or more property names to bind TargetName to.",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "targetType": {
+                    "type": "array",
+                    "description": "Specifies one or more property names to bind TargetType to.",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "additionalProperties": false
+        },
+        "execution": {
+            "type": "object",
+            "description": "Options that affect rule execution.",
+            "properties": {
+                "languageMode": {
+                    "type": "string",
+                    "description": "The PowerShell language mode to use for rule execution.",
+                    "enum": [
+                        "FullLanguage",
+                        "ConstrainedLanguage"
+                    ],
+                    "default": "FullLanguage"
+                },
+                "inconclusiveWarning": {
+                    "type": "boolean",
+                    "description": "Enable or disable warnings for inconclusive rules.",
+                    "default": true
+                },
+                "notProcessedWarning": {
+                    "type": "boolean",
+                    "description": "Enable or disable warnings for objects that are not processed by any rule.",
+                    "default": true
+                }
+            },
+            "additionalProperties": false
+        },
+        "input-v0.3.0": {
+            "type": "object",
+            "description": "Options that affect how input types are processed.",
+            "properties": {
+                "format": {
+                    "type": "string",
+                    "description": "The input string format.",
+                    "enum": [
+                        "None",
+                        "Yaml",
+                        "Json"
+                    ],
+                    "default": "None"
+                },
+                "objectPath": {
+                    "type": "string",
+                    "description": "The object path to a property to use instead of the pipeline object."
+                }
+            },
+            "additionalProperties": false
+        },
+        "logging-v0.4.0": {
+            "type": "object",
+            "description": "Options for logging outcomes to a informational streams.",
+            "properties": {
+                "ruleFail": {
+                    "type": "string",
+                    "description": "Log fail outcomes for each rule to a specific informational stream.",
+                    "enum": [
+                        "None",
+                        "Error",
+                        "Warning",
+                        "Information"
+                    ],
+                    "default": "None"
+                },
+                "rulePass": {
+                    "type": "string",
+                    "description": "Log pass outcomes for each rule to a specific informational stream.",
+                    "enum": [
+                        "None",
+                        "Error",
+                        "Warning",
+                        "Information"
+                    ],
+                    "default": "None"
+                },
+                "additionalProperties": false
+            }
+        },
+        "suppression-v0.2.0": {
+            "type": "object",
+            "description": "Specifies suppression rules."
+        },
+        "options-v0.2.0": {
+            "properties": {
+                "baseline": {
+                    "type": "object",
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/baseline-v0.2.0"
+                        }
+                    ]
+                },
+                "binding": {
+                    "type": "object",
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/binding-v0.2.0"
+                        }
+                    ]
+                },
+                "execution": {
+                    "type": "object",
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/execution"
+                        }
+                    ]
+                },
+                "suppression": {
+                    "type": "object",
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/suppression-v0.2.0"
+                        }
+                    ]
+                }
+            },
+            "additionalProperties": false
+        },
+        "options-v0.3.0": {
+            "properties": {
+                "baseline": {
+                    "type": "object",
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/baseline-v0.2.0"
+                        }
+                    ]
+                },
+                "binding": {
+                    "type": "object",
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/binding-v0.3.0"
+                        }
+                    ]
+                },
+                "execution": {
+                    "type": "object",
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/execution"
+                        }
+                    ]
+                },
+                "input": {
+                    "type": "object",
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/input-v0.3.0"
+                        }
+                    ]
+                },
+                "suppression": {
+                    "type": "object",
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/suppression-v0.2.0"
+                        }
+                    ]
+                }
+            },
+            "additionalProperties": false
+        },
+        "options-v0.4.0": {
+            "properties": {
+                "baseline": {
+                    "type": "object",
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/baseline-v0.2.0"
+                        }
+                    ]
+                },
+                "binding": {
+                    "type": "object",
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/binding-v0.3.0"
+                        }
+                    ]
+                },
+                "execution": {
+                    "type": "object",
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/execution"
+                        }
+                    ]
+                },
+                "input": {
+                    "type": "object",
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/input-v0.3.0"
+                        }
+                    ]
+                },
+                "logging": {
+                    "type": "object",
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/logging-v0.4.0"
+                        }
+                    ]
+                },
+                "suppression": {
+                    "type": "object",
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/suppression-v0.2.0"
+                        }
+                    ]
+                }
+            },
+            "additionalProperties": false
+        }
+    }
+}

--- a/src/PSRule/Configuration/InputOption.cs
+++ b/src/PSRule/Configuration/InputOption.cs
@@ -2,6 +2,9 @@
 
 namespace PSRule.Configuration
 {
+    /// <summary>
+    /// Options that affect how input types are processed.
+    /// </summary>
     public sealed class InputOption
     {
         private const InputFormat DEFAULT_FORMAT = PSRule.Configuration.InputFormat.None;
@@ -25,9 +28,15 @@ namespace PSRule.Configuration
             ObjectPath = option.ObjectPath;
         }
 
+        /// <summary>
+        /// The input string format.
+        /// </summary>
         [DefaultValue(null)]
         public InputFormat? Format { get; set; }
 
+        /// <summary>
+        /// The object path to a property to use instead of the pipeline object.
+        /// </summary>
         [DefaultValue(null)]
         public string ObjectPath { get; set; }
     }

--- a/src/PSRule/Configuration/LoggingOption.cs
+++ b/src/PSRule/Configuration/LoggingOption.cs
@@ -1,0 +1,43 @@
+﻿using System.ComponentModel;
+
+namespace PSRule.Configuration
+{
+    /// <summary>
+    /// Options for logging outcomes to a informational streams.
+    /// </summary>
+    public sealed class LoggingOption
+    {
+        private const OutcomeLogStream DEFAULT_RULEFAIL = OutcomeLogStream.None;
+        private const OutcomeLogStream DEFAULT_RULEPASS = OutcomeLogStream.None;
+
+        public static readonly LoggingOption Default = new LoggingOption
+        {
+            RuleFail = DEFAULT_RULEFAIL,
+            RulePass = DEFAULT_RULEPASS
+        };
+
+        public LoggingOption()
+        {
+            RuleFail = null;
+            RulePass = null;
+        }
+
+        public LoggingOption(LoggingOption option)
+        {
+            RuleFail = option.RuleFail;
+            RulePass = option.RulePass;
+        }
+
+        /// <summary>
+        /// Log fail outcomes for each rule to a specific informational stream.
+        /// </summary>
+        [DefaultValue(null)]
+        public OutcomeLogStream? RuleFail { get; set; }
+
+        /// <summary>
+        /// Log pass outcomes for each rule to a specific informational stream.
+        /// </summary>
+        [DefaultValue(null)]
+        public OutcomeLogStream? RulePass { get; set; }
+    }
+}

--- a/src/PSRule/Configuration/OutcomeLogStream.cs
+++ b/src/PSRule/Configuration/OutcomeLogStream.cs
@@ -1,0 +1,32 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace PSRule.Configuration
+{
+    /// <summary>
+    /// The PowerShell informational stream to log specific outcomes to.
+    /// </summary>
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum OutcomeLogStream : byte
+    {
+        /// <summary>
+        /// Outcomes will not be logged to an informational stream.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Log to Error stream.
+        /// </summary>
+        Error = 1,
+
+        /// <summary>
+        /// Log to Warning stream.
+        /// </summary>
+        Warning = 2,
+
+        /// <summary>
+        /// Log to Information stream.
+        /// </summary>
+        Information = 3
+    }
+}

--- a/src/PSRule/Configuration/PSRuleOption.cs
+++ b/src/PSRule/Configuration/PSRuleOption.cs
@@ -22,7 +22,8 @@ namespace PSRule.Configuration
         {
             Binding = BindingOption.Default,
             Execution = ExecutionOption.Default,
-            Input = InputOption.Default
+            Input = InputOption.Default,
+            Logging = LoggingOption.Default
         };
 
         public PSRuleOption()
@@ -31,6 +32,7 @@ namespace PSRule.Configuration
             Baseline = new BaselineOption();
             Binding = new BindingOption();
             Input = new InputOption();
+            Logging = new LoggingOption();
             Suppression = new SuppressionOption();
             Execution = new ExecutionOption();
             Pipeline = new PipelineHook();
@@ -42,6 +44,7 @@ namespace PSRule.Configuration
             Baseline = new BaselineOption(option.Baseline);
             Binding = new BindingOption(option.Binding);
             Input = new InputOption(option.Input);
+            Logging = new LoggingOption(option.Logging);
             Suppression = new SuppressionOption(option.Suppression);
             Execution = new ExecutionOption(option.Execution);
             Pipeline = new PipelineHook(option.Pipeline);
@@ -67,7 +70,15 @@ namespace PSRule.Configuration
         /// </summary>
         public ExecutionOption Execution { get; set; }
 
+        /// <summary>
+        /// Options that affect how input types are processed.
+        /// </summary>
         public InputOption Input { get; set; }
+
+        /// <summary>
+        /// Options for logging outcomes to a informational streams.
+        /// </summary>
+        public LoggingOption Logging { get; set; }
 
         /// <summary>
         /// A set of suppression rules.
@@ -220,6 +231,16 @@ namespace PSRule.Configuration
             if (index.TryGetValue("input.objectpath", out value))
             {
                 option.Input.ObjectPath = (string)value;
+            }
+
+            if (index.TryGetValue("logging.rulefail", out value))
+            {
+                option.Logging.RuleFail = (OutcomeLogStream)Enum.Parse(typeof(OutcomeLogStream), (string)value);
+            }
+
+            if (index.TryGetValue("logging.rulepass", out value))
+            {
+                option.Logging.RulePass = (OutcomeLogStream)Enum.Parse(typeof(OutcomeLogStream), (string)value);
             }
 
             return option;

--- a/src/PSRule/Pipeline/InvokeRulePipeline.cs
+++ b/src/PSRule/Pipeline/InvokeRulePipeline.cs
@@ -194,10 +194,12 @@ namespace PSRule.Pipeline
             if (outcome == RuleOutcome.Pass)
             {
                 s.Pass++;
+                _Context.Pass();
             }
             else if (outcome == RuleOutcome.Fail)
             {
                 s.Fail++;
+                _Context.Fail();
             }
             else if (outcome == RuleOutcome.Error)
             {

--- a/src/PSRule/Pipeline/InvokeRulePipelineBuilder.cs
+++ b/src/PSRule/Pipeline/InvokeRulePipelineBuilder.cs
@@ -75,7 +75,7 @@ namespace PSRule.Pipeline
             _LogError = !(error == ActionPreference.Ignore);
             _LogWarning = !(warning == ActionPreference.Ignore);
             _LogVerbose = !(verbose == ActionPreference.Ignore || verbose == ActionPreference.SilentlyContinue);
-            _LogInformation = !(information == ActionPreference.Ignore || information == ActionPreference.SilentlyContinue);
+            _LogInformation = !(information == ActionPreference.Ignore);
         }
 
         public void AddBindTargetNameAction(BindTargetNameAction action)
@@ -120,6 +120,9 @@ namespace PSRule.Pipeline
 
             _Option.Input.Format = option.Input.Format ?? InputOption.Default.Format;
             _Option.Input.ObjectPath = option.Input.ObjectPath ?? InputOption.Default.ObjectPath;
+
+            _Option.Logging.RuleFail = option.Logging.RuleFail ?? LoggingOption.Default.RuleFail;
+            _Option.Logging.RulePass = option.Logging.RulePass ?? LoggingOption.Default.RulePass;
 
             _Option.Binding.IgnoreCase = option.Binding.IgnoreCase ?? BindingOption.Default.IgnoreCase;
 

--- a/src/PSRule/Resources/PSRuleResources.Designer.cs
+++ b/src/PSRule/Resources/PSRuleResources.Designer.cs
@@ -70,6 +70,24 @@ namespace PSRule.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to [FAIL] -- {0}:: Reported for &apos;{1}&apos;.
+        /// </summary>
+        internal static string OutcomeRuleFail {
+            get {
+                return ResourceManager.GetString("OutcomeRuleFail", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to [PASS] -- {0}:: Reported for &apos;{1}&apos;.
+        /// </summary>
+        internal static string OutcomeRulePass {
+            get {
+                return ResourceManager.GetString("OutcomeRulePass", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Inconclusive result reported for &apos;{1}&apos; @{0}..
         /// </summary>
         internal static string RuleInconclusive {

--- a/src/PSRule/Resources/PSRuleResources.resx
+++ b/src/PSRule/Resources/PSRuleResources.resx
@@ -120,6 +120,12 @@
   <data name="ObjectNotProcessed" xml:space="preserve">
     <value>Target object '{0}' has not been processed because no matching rules were found.</value>
   </data>
+  <data name="OutcomeRuleFail" xml:space="preserve">
+    <value>[FAIL] -- {0}:: Reported for '{1}'</value>
+  </data>
+  <data name="OutcomeRulePass" xml:space="preserve">
+    <value>[PASS] -- {0}:: Reported for '{1}'</value>
+  </data>
   <data name="RuleInconclusive" xml:space="preserve">
     <value>Inconclusive result reported for '{1}' @{0}.</value>
   </data>

--- a/tests/PSRule.Tests/PSRule.Common.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Common.Tests.ps1
@@ -461,6 +461,74 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
             $result.TargetType | Should -Be 'OtherType';
         }
     }
+
+    Context 'Logging' {
+        It 'RuleFail' {
+            $testObject = [PSCustomObject]@{
+                Name = 'LoggingTest'
+            }
+
+            # Warning
+            $option = New-PSRuleOption -Option @{ 'Logging.RuleFail' = 'Warning'};
+            $result = $testObject | Invoke-PSRule -Option $option -Path (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1') -Name 'FromFile2' -WarningVariable outWarning -WarningAction SilentlyContinue;
+            $messages = @($outwarning);
+            $result | Should -Not -BeNullOrEmpty;
+            $result.Outcome | Should -Be 'Fail';
+            $messages | Should -Not -BeNullOrEmpty;
+            $messages | Should -Be "[FAIL] -- FromFile2:: Reported for 'LoggingTest'"
+
+            # Error
+            $option = New-PSRuleOption -Option @{ 'Logging.RuleFail' = 'Error'};
+            $result = $testObject | Invoke-PSRule -Option $option -Path (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1') -Name 'FromFile2' -ErrorVariable outError -ErrorAction SilentlyContinue;
+            $messages = @($outError);
+            $result | Should -Not -BeNullOrEmpty;
+            $result.Outcome | Should -Be 'Fail';
+            $messages | Should -Not -BeNullOrEmpty;
+            $messages.Exception.Message | Should -Be "[FAIL] -- FromFile2:: Reported for 'LoggingTest'"
+
+            # Information
+            $option = New-PSRuleOption -Option @{ 'Logging.RuleFail' = 'Information'};
+            $result = $testObject | Invoke-PSRule -Option $option -Path (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1') -Name 'FromFile2' -InformationVariable outInformation;
+            $messages = @($outInformation);
+            $result | Should -Not -BeNullOrEmpty;
+            $result.Outcome | Should -Be 'Fail';
+            $messages | Should -Not -BeNullOrEmpty;
+            $messages | Should -Be "[FAIL] -- FromFile2:: Reported for 'LoggingTest'"
+        }
+
+        It 'RulePass' {
+            $testObject = [PSCustomObject]@{
+                Name = 'LoggingTest'
+            }
+
+            # Warning
+            $option = New-PSRuleOption -Option @{ 'Logging.RulePass' = 'Warning'};
+            $result = $testObject | Invoke-PSRule -Option $option -Path (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1') -Name 'FromFile1' -WarningVariable outWarning -WarningAction SilentlyContinue;
+            $messages = @($outwarning);
+            $result | Should -Not -BeNullOrEmpty;
+            $result.Outcome | Should -Be 'Pass';
+            $messages | Should -Not -BeNullOrEmpty;
+            $messages | Should -Be "[PASS] -- FromFile1:: Reported for 'LoggingTest'"
+
+            # Error
+            $option = New-PSRuleOption -Option @{ 'Logging.RulePass' = 'Error'};
+            $result = $testObject | Invoke-PSRule -Option $option -Path (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1') -Name 'FromFile1' -ErrorVariable outError -ErrorAction SilentlyContinue;
+            $messages = @($outError);
+            $result | Should -Not -BeNullOrEmpty;
+            $result.Outcome | Should -Be 'Pass';
+            $messages | Should -Not -BeNullOrEmpty;
+            $messages.Exception.Message | Should -Be "[PASS] -- FromFile1:: Reported for 'LoggingTest'"
+
+            # Information
+            $option = New-PSRuleOption -Option @{ 'Logging.RulePass' = 'Information'};
+            $result = $testObject | Invoke-PSRule -Option $option -Path (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1') -Name 'FromFile1' -InformationVariable outInformation;
+            $messages = @($outInformation);
+            $result | Should -Not -BeNullOrEmpty;
+            $result.Outcome | Should -Be 'Pass';
+            $messages | Should -Not -BeNullOrEmpty;
+            $messages | Should -Be "[PASS] -- FromFile1:: Reported for 'LoggingTest'"
+        }
+    }
 }
 
 #endregion Invoke-PSRule
@@ -860,6 +928,40 @@ Describe 'New-PSRuleOption' -Tag 'Option','Common','New-PSRuleOption' {
         It 'from YAML' {
             $option = New-PSRuleOption -Option (Join-Path -Path $here -ChildPath 'PSRule.Tests.yml');
             $option.Input.ObjectPath | Should -Be 'items';
+        }
+    }
+
+    Context 'Read Logging.RuleFail' {
+        It 'from default' {
+            $option = New-PSRuleOption;
+            $option.Logging.RuleFail | Should -Be 'None';
+        }
+
+        It 'from Hashtable' {
+            $option = New-PSRuleOption -Option @{ 'Logging.RuleFail' = 'Error' };
+            $option.Logging.RuleFail | Should -Be Error;
+        }
+
+        It 'from YAML' {
+            $option = New-PSRuleOption -Option (Join-Path -Path $here -ChildPath 'PSRule.Tests.yml');
+            $option.Logging.RuleFail | Should -Be Warning;
+        }
+    }
+
+    Context 'Read Logging.RulePass' {
+        It 'from default' {
+            $option = New-PSRuleOption;
+            $option.Logging.RulePass | Should -Be 'None';
+        }
+
+        It 'from Hashtable' {
+            $option = New-PSRuleOption -Option @{ 'Logging.RulePass' = 'Error' };
+            $option.Logging.RulePass | Should -Be Error;
+        }
+
+        It 'from YAML' {
+            $option = New-PSRuleOption -Option (Join-Path -Path $here -ChildPath 'PSRule.Tests.yml');
+            $option.Logging.RulePass | Should -Be Warning;
         }
     }
 

--- a/tests/PSRule.Tests/PSRule.Tests.yml
+++ b/tests/PSRule.Tests/PSRule.Tests.yml
@@ -30,6 +30,11 @@ input:
   format: Yaml
   objectPath: items
 
+# Configures outcome logging options
+logging:
+  ruleFail: Warning
+  rulePass: Warning
+
 # Configure rule suppression
 suppression:
   SuppressionTest1:


### PR DESCRIPTION
## PR Summary

- Added support for logging pass or fail outcomes to a data stream such as Error, Warning or Information #97

Fixes #97 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/BernieWhite/PSRule/blob/master/CHANGELOG.md) has been updated with change under unreleased section
