### PR TITLE
Removed deprecated Hint -TargetName parameter #81

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## Unreleased
 
 - Added support for logging pass or fail outcomes to a data stream such as Error, Warning or Information [#97](https://github.com/BernieWhite/PSRule/issues/97)
+- **Breaking change** - Deprecated usage of the `-TargetName` parameter on the `Hint` keyword has been removed [#81](https://github.com/BernieWhite/PSRule/issues/81)
 
 ## v0.3.0
 

--- a/src/PSRule/Commands/SetPSRuleHintCommand.cs
+++ b/src/PSRule/Commands/SetPSRuleHintCommand.cs
@@ -12,9 +12,6 @@ namespace PSRule.Commands
         [Parameter(Mandatory = false, Position = 0)]
         public string Message { get; set; }
 
-        [Parameter(Mandatory = false)]
-        public string TargetName { get; set; }
-
         protected override void ProcessRecord()
         {
             var result = GetResult();
@@ -22,11 +19,6 @@ namespace PSRule.Commands
             if (MyInvocation.BoundParameters.ContainsKey("Message"))
             {
                 result.Message = Message;
-            }
-
-            if (MyInvocation.BoundParameters.ContainsKey("TargetName"))
-            {
-                PipelineContext.CurrentThread.WarnTargetNameParameterObsolete();
             }
         }
     }

--- a/src/PSRule/Pipeline/PipelineContext.cs
+++ b/src/PSRule/Pipeline/PipelineContext.cs
@@ -212,16 +212,6 @@ namespace PSRule.Pipeline
             DoWriteWarning(string.Format(PSRuleResources.RuleInconclusive, ruleId, TargetName));
         }
 
-        public void WarnTargetNameParameterObsolete()
-        {
-            if (!_LogWarning)
-            {
-                return;
-            }
-
-            DoWriteWarning(PSRuleResources.TargetNameParameterObsolete);
-        }
-
         public void Pass()
         {
             if (_PassStream == OutcomeLogStream.None)

--- a/src/PSRule/Resources/PSRuleResources.Designer.cs
+++ b/src/PSRule/Resources/PSRuleResources.Designer.cs
@@ -104,14 +104,5 @@ namespace PSRule.Resources {
                 return ResourceManager.GetString("RuleNotFound", resourceCulture);
             }
         }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Hint parameter -TargetName is obsolete and has been replaced with TargetName binding. See about_PSRule_Options for details on how to set Binding.TargetName..
-        /// </summary>
-        internal static string TargetNameParameterObsolete {
-            get {
-                return ResourceManager.GetString("TargetNameParameterObsolete", resourceCulture);
-            }
-        }
     }
 }

--- a/src/PSRule/Resources/PSRuleResources.resx
+++ b/src/PSRule/Resources/PSRuleResources.resx
@@ -132,7 +132,4 @@
   <data name="RuleNotFound" xml:space="preserve">
     <value>Could not find a matching rule. Please check that Path, Name and Tag parameters are correct.</value>
   </data>
-  <data name="TargetNameParameterObsolete" xml:space="preserve">
-    <value>Hint parameter -TargetName is obsolete and has been replaced with TargetName binding. See about_PSRule_Options for details on how to set Binding.TargetName.</value>
-  </data>
 </root>

--- a/tests/PSRule.Tests/FromFile.Rule.ps1
+++ b/tests/PSRule.Tests/FromFile.Rule.ps1
@@ -136,7 +136,7 @@ Rule 'WithFormat' {
 
 # Description: Test for Hint keyword
 Rule 'HintTest' {
-    Hint 'This is a message' -TargetName 'HintTarget'
+    Hint 'This is a message'
 }
 
 # Description: Test for Hint keyword

--- a/tests/PSRule.Tests/PSRule.Hint.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Hint.Tests.ps1
@@ -28,13 +28,12 @@ Describe 'PSRule -- Hint keyword' -Tag 'Hint' {
 
         It 'Sets result properties' {
             $option = @{ 'Execution.InconclusiveWarning' = $False };
-            $result = $testObject | Invoke-PSRule -Path (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1') -Option $option -Name 'HintTest' -Outcome All -WarningVariable outWarning -WarningAction SilentlyContinue;
+            $result = $testObject | Invoke-PSRule -Path (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1') -Option $option -Name 'HintTest' -Outcome All -WarningVariable outWarning;
             $warningMessages = @($outWarning);
             $result | Should -Not -BeNullOrEmpty;
             $result.RuleName | Should -Be 'HintTest';
             $result.Message | Should -Be 'This is a message';
-            $warningMessages.Length | Should -Be 1;
-            $warningMessages | Should -Be "Hint parameter -TargetName is obsolete and has been replaced with TargetName binding. See about_PSRule_Options for details on how to set Binding.TargetName.";
+            $warningMessages.Length | Should -Be 0;
         }
 
         It 'Uses description' {


### PR DESCRIPTION
## PR Summary

- Deprecated usage of the `-TargetName` parameter on the `Hint` keyword has been removed #81

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/BernieWhite/PSRule/blob/master/CHANGELOG.md) has been updated with change under unreleased section
