### PR TITLE
Add and update cmdlets to set options from parameters #135 #134

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 ## Unreleased
 
 - Added `-OutputFormat NUnit3` to `Invoke-PSRule` return NUnit formatted output. [#129](https://github.com/BernieWhite/PSRule/issues/129)
+- Added `Set-PSRuleOption` cmdlet to configure YAML options file. [#135](https://github.com/BernieWhite/PSRule/issues/135)
+- Added parameters to New-PSRuleOption to configure common options. [#134](https://github.com/BernieWhite/PSRule/issues/134)
+  - Additional parameter are an alternative to using a `-Option` hashtable.
 
 ## v0.5.0-B190405 (pre-release)
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ The following commands exist in the `PSRule` module:
 - [Get-PSRule](docs/commands/PSRule/en-US/Get-PSRule.md) - Get a list of rule definitions.
 - [Invoke-PSRule](docs/commands/PSRule/en-US/Invoke-PSRule.md) - Evaluate objects against matching rules.
 - [New-PSRuleOption](docs/commands/PSRule/en-US/New-PSRuleOption.md) - Create options to configure PSRule execution.
+- [Set-PSRuleOption](docs/commands/PSRule/en-US/Set-PSRuleOption.md) - Sets options that configure PSRule execution.
 - [Test-PSRuleTarget](docs/commands/PSRule/en-US/Test-PSRuleTarget.md) - Pass or fail objects against matching rules.
 
 ### Concepts

--- a/docs/commands/PSRule/en-US/Get-PSRule.md
+++ b/docs/commands/PSRule/en-US/Get-PSRule.md
@@ -2,6 +2,7 @@
 external help file: PSRule-help.xml
 Module Name: PSRule
 online version: https://berniewhite.github.io/PSRule/commands/PSRule/en-US/Get-PSRule.html
+schema: 2.0.0
 ---
 
 # Get-PSRule

--- a/docs/commands/PSRule/en-US/Invoke-PSRule.md
+++ b/docs/commands/PSRule/en-US/Invoke-PSRule.md
@@ -2,6 +2,7 @@
 external help file: PSRule-help.xml
 Module Name: PSRule
 online version: https://berniewhite.github.io/PSRule/commands/PSRule/en-US/Invoke-PSRule.html
+schema: 2.0.0
 ---
 
 # Invoke-PSRule

--- a/docs/commands/PSRule/en-US/New-PSRuleOption.md
+++ b/docs/commands/PSRule/en-US/New-PSRuleOption.md
@@ -196,3 +196,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## RELATED LINKS
 
 [Invoke-PSRule](Invoke-PSRule.md)
+[Set-PSRuleOption](Set-PSRuleOption.md)

--- a/docs/commands/PSRule/en-US/New-PSRuleOption.md
+++ b/docs/commands/PSRule/en-US/New-PSRuleOption.md
@@ -2,6 +2,7 @@
 external help file: PSRule-help.xml
 Module Name: PSRule
 online version: https://berniewhite.github.io/PSRule/commands/PSRule/en-US/New-PSRuleOption.html
+schema: 2.0.0
 ---
 
 # New-PSRuleOption
@@ -13,9 +14,14 @@ Create options to configure PSRule execution.
 ## SYNTAX
 
 ```text
-New-PSRuleOption [[-Option] <PSRuleOption>] [-BaselineConfiguration <BaselineConfiguration>]
+New-PSRuleOption [[-Path] <String>] [[-Option] <PSRuleOption>] [-BaselineConfiguration <BaselineConfiguration>]
  [-SuppressTargetName <SuppressionOption>] [-BindTargetName <BindTargetName[]>]
- [-BindTargetType <BindTargetName[]>] [[-Path] <String>] [<CommonParameters>]
+ [-BindTargetType <BindTargetName[]>] [-BindingIgnoreCase <Boolean>] [-BindingTargetName <String[]>]
+ [-BindingTargetType <String[]>] [-ExecutionLanguageMode <LanguageMode>]
+ [-ExecutionInconclusiveWarning <Boolean>] [-ExecutionNotProcessedWarning <Boolean>]
+ [-InputFormat <InputFormat>] [-InputObjectPath <String>] [-LoggingRuleFail <OutcomeLogStream>]
+ [-LoggingRulePass <OutcomeLogStream>] [-OutputAs <ResultFormat>] [-OutputFormat <OutputFormat>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -169,6 +175,182 @@ For more information on PSRule options see about_PSRule_Options.
 
 ```yaml
 Type: BindTargetName[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -BindingIgnoreCase
+
+{{ Fill BindingIgnoreCase Description }}
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TargetName
+
+{{ Fill BindingTargetName Description }}
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TargetType
+
+{{ Fill BindingTargetType Description }}
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -InconclusiveWarning
+
+{{ Fill ExecutionInconclusiveWarning Description }}
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -NotProcessedWarning
+
+{{ Fill ExecutionNotProcessedWarning Description }}
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Format
+
+{{ Fill InputFormat Description }}
+
+```yaml
+Type: InputFormat
+Parameter Sets: (All)
+Aliases: Format
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ObjectPath
+
+{{ Fill InputObjectPath Description }}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: ObjectPath
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -LoggingRuleFail
+
+{{ Fill LoggingRuleFail Description }}
+
+```yaml
+Type: OutcomeLogStream
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -LoggingRulePass
+
+{{ Fill LoggingRulePass Description }}
+
+```yaml
+Type: OutcomeLogStream
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OutputAs
+
+{{ Fill OutputAs Description }}
+
+```yaml
+Type: ResultFormat
+Parameter Sets: (All)
+Aliases: As
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OutputFormat
+
+{{ Fill OutputFormat Description }}
+
+```yaml
+Type: OutputFormat
 Parameter Sets: (All)
 Aliases:
 

--- a/docs/commands/PSRule/en-US/New-PSRuleOption.md
+++ b/docs/commands/PSRule/en-US/New-PSRuleOption.md
@@ -16,10 +16,9 @@ Create options to configure PSRule execution.
 ```text
 New-PSRuleOption [[-Path] <String>] [[-Option] <PSRuleOption>] [-BaselineConfiguration <BaselineConfiguration>]
  [-SuppressTargetName <SuppressionOption>] [-BindTargetName <BindTargetName[]>]
- [-BindTargetType <BindTargetName[]>] [-BindingIgnoreCase <Boolean>] [-BindingTargetName <String[]>]
- [-BindingTargetType <String[]>] [-ExecutionLanguageMode <LanguageMode>]
- [-ExecutionInconclusiveWarning <Boolean>] [-ExecutionNotProcessedWarning <Boolean>]
- [-InputFormat <InputFormat>] [-InputObjectPath <String>] [-LoggingRuleFail <OutcomeLogStream>]
+ [-BindTargetType <BindTargetName[]>] [-BindingIgnoreCase <Boolean>] [-TargetName <String[]>]
+ [-TargetType <String[]>] [-InconclusiveWarning <Boolean>] [-NotProcessedWarning <Boolean>]
+ [-Format <InputFormat>] [-ObjectPath <String>] [-LoggingRuleFail <OutcomeLogStream>]
  [-LoggingRulePass <OutcomeLogStream>] [-OutputAs <ResultFormat>] [-OutputFormat <OutputFormat>]
  [<CommonParameters>]
 ```
@@ -99,7 +98,11 @@ Accept wildcard characters: False
 
 ### -Path
 
-The path to a YAML file containing options.
+The path to a YAML file containing options. By default the current working path (`$PWD`) is used.
+
+Either a directory or file path can be specified. When a directory is used, `ps-rule.yaml` will be used as the file name.
+
+If the `-Path` parameter is specified and the file does not exist, an exception will be generated.
 
 ```yaml
 Type: String
@@ -187,7 +190,7 @@ Accept wildcard characters: False
 
 ### -BindingIgnoreCase
 
-{{ Fill BindingIgnoreCase Description }}
+Sets the option `Binding.IgnoreCase`. The option `Binding.IgnoreCase` determines if binding operations are case-sensitive or not. See about_PSRule_Options for more information.
 
 ```yaml
 Type: Boolean
@@ -203,12 +206,12 @@ Accept wildcard characters: False
 
 ### -TargetName
 
-{{ Fill BindingTargetName Description }}
+Sets the option `Binding.TargetName`. This option specifies one or more properties of _TargetObject_ to use to bind _TargetName_ to. See about_PSRule_Options for more information.
 
 ```yaml
 Type: String[]
 Parameter Sets: (All)
-Aliases:
+Aliases: BindingTargetName
 
 Required: False
 Position: Named
@@ -219,12 +222,12 @@ Accept wildcard characters: False
 
 ### -TargetType
 
-{{ Fill BindingTargetType Description }}
+Sets the option `Binding.TargetType`. This option specifies one or more properties of _TargetObject_ to use to bind _TargetType_ to. See about_PSRule_Options for more information.
 
 ```yaml
 Type: String[]
 Parameter Sets: (All)
-Aliases:
+Aliases: BindingTargetType
 
 Required: False
 Position: Named
@@ -235,12 +238,12 @@ Accept wildcard characters: False
 
 ### -InconclusiveWarning
 
-{{ Fill ExecutionInconclusiveWarning Description }}
+Sets the option `Execution.InconclusiveWarning`. The `Execution.InconclusiveWarning` option determines if a warning is generated when the outcome of a rule is inconclusive. See about_PSRule_Options for more information.
 
 ```yaml
 Type: Boolean
 Parameter Sets: (All)
-Aliases:
+Aliases: ExecutionInconclusiveWarning
 
 Required: False
 Position: Named
@@ -251,12 +254,12 @@ Accept wildcard characters: False
 
 ### -NotProcessedWarning
 
-{{ Fill ExecutionNotProcessedWarning Description }}
+Sets the option `Execution.NotProcessedWarning`. The `Execution.NotProcessedWarning` option determines if a warning is generated when an object is not processed by any rule. See about_PSRule_Options for more information.
 
 ```yaml
 Type: Boolean
 Parameter Sets: (All)
-Aliases:
+Aliases: ExecutionNotProcessedWarning
 
 Required: False
 Position: Named
@@ -267,12 +270,12 @@ Accept wildcard characters: False
 
 ### -Format
 
-{{ Fill InputFormat Description }}
+Sets the `Input.Format` option to configure the input format for when a string is passed in as a target object.
 
 ```yaml
 Type: InputFormat
 Parameter Sets: (All)
-Aliases: Format
+Aliases: InputFormat
 
 Required: False
 Position: Named
@@ -283,12 +286,12 @@ Accept wildcard characters: False
 
 ### -ObjectPath
 
-{{ Fill InputObjectPath Description }}
+Sets the `Input.ObjectPath` option to use an object path to use instead of the pipeline object.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: ObjectPath
+Aliases: InputObjectPath
 
 Required: False
 Position: Named
@@ -299,7 +302,7 @@ Accept wildcard characters: False
 
 ### -LoggingRuleFail
 
-{{ Fill LoggingRuleFail Description }}
+Sets the `Logging.RuleFail` option to generate an informational message for each rule fail.
 
 ```yaml
 Type: OutcomeLogStream
@@ -315,7 +318,7 @@ Accept wildcard characters: False
 
 ### -LoggingRulePass
 
-{{ Fill LoggingRulePass Description }}
+Sets the `Logging.RulePass` option to generate an informational message for each rule pass.
 
 ```yaml
 Type: OutcomeLogStream
@@ -331,12 +334,12 @@ Accept wildcard characters: False
 
 ### -OutputAs
 
-{{ Fill OutputAs Description }}
+Sets the option `Output.As`. The `Output.As` option configures the type of results to produce, either detail or summary.
 
 ```yaml
 Type: ResultFormat
 Parameter Sets: (All)
-Aliases: As
+Aliases:
 
 Required: False
 Position: Named
@@ -347,7 +350,7 @@ Accept wildcard characters: False
 
 ### -OutputFormat
 
-{{ Fill OutputFormat Description }}
+Sets the option `Output.Format`. The `Output.Format` option configures the format that results will be presented in.
 
 ```yaml
 Type: OutputFormat

--- a/docs/commands/PSRule/en-US/PSRule.md
+++ b/docs/commands/PSRule/en-US/PSRule.md
@@ -26,6 +26,10 @@ Evaluate pipeline objects against matching rules.
 
 Create options to configure PSRule execution.
 
+### [Set-PSRuleOption](Set-PSRuleOption.md)
+
+Set options to configure PSRule execution.
+
 ### [Test-PSRuleTarget](Test-PSRuleTarget.md)
 
 Evaluate pipeline objects against matching rules.

--- a/docs/commands/PSRule/en-US/Set-PSRuleOption.md
+++ b/docs/commands/PSRule/en-US/Set-PSRuleOption.md
@@ -14,7 +14,7 @@ Sets options that configure PSRule execution.
 ## SYNTAX
 
 ```text
-Set-PSRuleOption [[-Path] <String>] [-Option <PSRuleOption>] [-PassThru] [-Force] [-Overwrite]
+Set-PSRuleOption [[-Path] <String>] [-Option <PSRuleOption>] [-PassThru] [-Force] [-AllowClobber]
  [-BindingIgnoreCase <Boolean>] [-TargetName <String[]>] [-TargetType <String[]>]
  [-InconclusiveWarning <Boolean>] [-NotProcessedWarning <Boolean>] [-Format <InputFormat>]
  [-ObjectPath <String>] [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>]
@@ -34,6 +34,14 @@ PS C:\> Set-PSRuleOption -OutputFormat Yaml;
 ```
 
 Sets the `Output.Format` to `Yaml` for `ps-rule.yaml` in the current working path. If the `ps-rule.yaml` file exists, it is merged with the existing file and overwritten. If the file does not exist, a new file is created.
+
+### Example 2
+
+```powershell
+PS C:\> Set-PSRuleOption -OutputFormat Yaml -Path .\project-options.yaml;
+```
+
+Sets the `Output.Format` to `Yaml` for `project-options.yaml` in the current working path. If the `project-options.yaml` file exists, it is merged with the existing file and overwritten. If the file does not exist, a new file is created.
 
 ## PARAMETERS
 
@@ -61,7 +69,7 @@ Accept wildcard characters: False
 
 ### -Option
 
-{{ Fill Option Description }}
+An options object to use.
 
 ```yaml
 Type: PSRuleOption
@@ -107,7 +115,7 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Overwrite
+### -AllowClobber
 
 Overwrite YAML files that contain comments.
 

--- a/docs/commands/PSRule/en-US/Set-PSRuleOption.md
+++ b/docs/commands/PSRule/en-US/Set-PSRuleOption.md
@@ -2,6 +2,7 @@
 external help file: PSRule-help.xml
 Module Name: PSRule
 online version: https://berniewhite.github.io/PSRule/commands/PSRule/en-US/Set-PSRuleOption.html
+schema: 2.0.0
 ---
 
 # Set-PSRuleOption
@@ -13,12 +14,11 @@ Sets options that configure PSRule execution.
 ## SYNTAX
 
 ```text
-Set-PSRuleOption [[-Path] <String>] [-Option <PSRuleOption>] [-PassThru] [-BindingIgnoreCase <Boolean>]
- [-BindingTargetName <String[]>] [-BindingTargetType <String[]>] [-ExecutionLanguageMode <LanguageMode>]
- [-ExecutionInconclusiveWarning <Boolean>] [-ExecutionNotProcessedWarning <Boolean>]
- [-InputFormat <InputFormat>] [-InputObjectPath <String>] [-LoggingRuleFail <OutcomeLogStream>]
- [-LoggingRulePass <OutcomeLogStream>] [-OutputAs <ResultFormat>] [-OutputFormat <OutputFormat>] [-WhatIf]
- [-Confirm] [<CommonParameters>]
+Set-PSRuleOption [[-Path] <String>] [-Option <PSRuleOption>] [-PassThru] [-Force] [-Overwrite]
+ [-BindingIgnoreCase <Boolean>] [-TargetName <String[]>] [-TargetType <String[]>]
+ [-InconclusiveWarning <Boolean>] [-NotProcessedWarning <Boolean>] [-Format <InputFormat>]
+ [-ObjectPath <String>] [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>]
+ [-OutputAs <ResultFormat>] [-OutputFormat <OutputFormat>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -44,6 +44,8 @@ The path to a YAML file where options will be set. By default the current workin
 Either a directory or file path can be specified. When a directory is used, `ps-rule.yaml` will be used as the file name.
 
 The file will be created if it does not exist. If the file already exists it will be merged with the existing options and **overwritten**.
+
+If the directory does not exist an error will be generated. To force the creation of the directory path use the `-Force` switch.
 
 ```yaml
 Type: String
@@ -89,9 +91,41 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Force
+
+Force creation of directory path for Path parameter, when the directory does not already exist.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Overwrite
+
+Overwrite YAML files that contain comments.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -BindingIgnoreCase
 
-Sets the option `Binding.IgnoreCase`. The option `Binding.IgnoreCase` determines if binding operations are case-sensitive or not. See [about_PSRule_Options][about_PSRule_Options] for more information.
+Sets the option `Binding.IgnoreCase`. The option `Binding.IgnoreCase` determines if binding operations are case-sensitive or not. See about_PSRule_Options for more information.
 
 ```yaml
 Type: Boolean
@@ -107,12 +141,12 @@ Accept wildcard characters: False
 
 ### -TargetName
 
-Sets the option `Binding.TargetName`. This option specifies one or more properties of _TargetObject_ to use to bind _TargetName_ to. See [about_PSRule_Options][about_PSRule_Options] for more information.
+Sets the option `Binding.TargetName`. This option specifies one or more properties of _TargetObject_ to use to bind _TargetName_ to. See about_PSRule_Options for more information.
 
 ```yaml
 Type: String[]
 Parameter Sets: (All)
-Aliases:
+Aliases: BindingTargetName
 
 Required: False
 Position: Named
@@ -123,12 +157,12 @@ Accept wildcard characters: False
 
 ### -TargetType
 
-Sets the option `Binding.TargetType`. This option specifies one or more properties of _TargetObject_ to use to bind _TargetType_ to. See [about_PSRule_Options][about_PSRule_Options] for more information.
+Sets the option `Binding.TargetType`. This option specifies one or more properties of _TargetObject_ to use to bind _TargetType_ to. See about_PSRule_Options for more information.
 
 ```yaml
 Type: String[]
 Parameter Sets: (All)
-Aliases:
+Aliases: BindingTargetType
 
 Required: False
 Position: Named
@@ -137,33 +171,14 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -ExecutionLanguageMode
-
-Sets the option `Execution.LanguageMode`. The `Execution.LanguageMode` option determines if all or limit PowerShell language features are available for rules.
-
-TODO: Get rid of this parameter.
-
-```yaml
-Type: LanguageMode
-Parameter Sets: (All)
-Aliases:
-Accepted values: FullLanguage, ConstrainedLanguage
-
-Required: False
-Position: Named
-Default value: FullLanguage
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -InconclusiveWarning
 
-Sets the option `Execution.InconclusiveWarning`. The `Execution.InconclusiveWarning` option determines if a warning is generated when the outcome of a rule is inconclusive. See [about_PSRule_Options][about_PSRule_Options] for more information.
+Sets the option `Execution.InconclusiveWarning`. The `Execution.InconclusiveWarning` option determines if a warning is generated when the outcome of a rule is inconclusive. See about_PSRule_Options for more information.
 
 ```yaml
 Type: Boolean
 Parameter Sets: (All)
-Aliases:
+Aliases: ExecutionInconclusiveWarning
 
 Required: False
 Position: Named
@@ -174,12 +189,12 @@ Accept wildcard characters: False
 
 ### -NotProcessedWarning
 
-Sets the option `Execution.NotProcessedWarning`. The `Execution.NotProcessedWarning` option determines if a warning is generated when an object is not processed by any rule. See [about_PSRule_Options][about_PSRule_Options] for more information.
+Sets the option `Execution.NotProcessedWarning`. The `Execution.NotProcessedWarning` option determines if a warning is generated when an object is not processed by any rule. See about_PSRule_Options for more information.
 
 ```yaml
 Type: Boolean
 Parameter Sets: (All)
-Aliases:
+Aliases: ExecutionNotProcessedWarning
 
 Required: False
 Position: Named
@@ -195,7 +210,7 @@ Sets the option `Input.Format`.
 ```yaml
 Type: InputFormat
 Parameter Sets: (All)
-Aliases: Format
+Aliases: InputFormat
 Accepted values: None, Yaml, Json, Detect
 
 Required: False
@@ -212,7 +227,7 @@ Sets the option `Input.ObjectPath`.
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: ObjectPath
+Aliases: InputObjectPath
 
 Required: False
 Position: Named
@@ -338,5 +353,3 @@ When you use the `-PassThru` switch, an options object is returned to the pipeli
 ## RELATED LINKS
 
 [New-PSRuleOption](New-PSRuleOption.md)
-
-[about_PSRule_Options]: ../../../concepts/PSRule/en-US/about_PSRule_Options.md

--- a/docs/commands/PSRule/en-US/Set-PSRuleOption.md
+++ b/docs/commands/PSRule/en-US/Set-PSRuleOption.md
@@ -1,0 +1,342 @@
+---
+external help file: PSRule-help.xml
+Module Name: PSRule
+online version: https://berniewhite.github.io/PSRule/commands/PSRule/en-US/Set-PSRuleOption.html
+---
+
+# Set-PSRuleOption
+
+## SYNOPSIS
+
+Sets options that configure PSRule execution.
+
+## SYNTAX
+
+```text
+Set-PSRuleOption [[-Path] <String>] [-Option <PSRuleOption>] [-PassThru] [-BindingIgnoreCase <Boolean>]
+ [-BindingTargetName <String[]>] [-BindingTargetType <String[]>] [-ExecutionLanguageMode <LanguageMode>]
+ [-ExecutionInconclusiveWarning <Boolean>] [-ExecutionNotProcessedWarning <Boolean>]
+ [-InputFormat <InputFormat>] [-InputObjectPath <String>] [-LoggingRuleFail <OutcomeLogStream>]
+ [-LoggingRulePass <OutcomeLogStream>] [-OutputAs <ResultFormat>] [-OutputFormat <OutputFormat>] [-WhatIf]
+ [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+Sets options that configure PSRule execution.
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+PS C:\> Set-PSRuleOption -OutputFormat Yaml;
+```
+
+Sets the `Output.Format` to `Yaml` for `ps-rule.yaml` in the current working path. If the `ps-rule.yaml` file exists, it is merged with the existing file and overwritten. If the file does not exist, a new file is created.
+
+## PARAMETERS
+
+### -Path
+
+The path to a YAML file where options will be set. By default the current working path (`$PWD`) is used.
+
+Either a directory or file path can be specified. When a directory is used, `ps-rule.yaml` will be used as the file name.
+
+The file will be created if it does not exist. If the file already exists it will be merged with the existing options and **overwritten**.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 1
+Default value: .\ps-rule.yml
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Option
+
+{{ Fill Option Description }}
+
+```yaml
+Type: PSRuleOption
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -PassThru
+
+Use this option to return the options object to the pipeline instead of saving to disk.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -BindingIgnoreCase
+
+Sets the option `Binding.IgnoreCase`. The option `Binding.IgnoreCase` determines if binding operations are case-sensitive or not. See [about_PSRule_Options][about_PSRule_Options] for more information.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TargetName
+
+Sets the option `Binding.TargetName`. This option specifies one or more properties of _TargetObject_ to use to bind _TargetName_ to. See [about_PSRule_Options][about_PSRule_Options] for more information.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TargetType
+
+Sets the option `Binding.TargetType`. This option specifies one or more properties of _TargetObject_ to use to bind _TargetType_ to. See [about_PSRule_Options][about_PSRule_Options] for more information.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ExecutionLanguageMode
+
+Sets the option `Execution.LanguageMode`. The `Execution.LanguageMode` option determines if all or limit PowerShell language features are available for rules.
+
+TODO: Get rid of this parameter.
+
+```yaml
+Type: LanguageMode
+Parameter Sets: (All)
+Aliases:
+Accepted values: FullLanguage, ConstrainedLanguage
+
+Required: False
+Position: Named
+Default value: FullLanguage
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -InconclusiveWarning
+
+Sets the option `Execution.InconclusiveWarning`. The `Execution.InconclusiveWarning` option determines if a warning is generated when the outcome of a rule is inconclusive. See [about_PSRule_Options][about_PSRule_Options] for more information.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: True
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -NotProcessedWarning
+
+Sets the option `Execution.NotProcessedWarning`. The `Execution.NotProcessedWarning` option determines if a warning is generated when an object is not processed by any rule. See [about_PSRule_Options][about_PSRule_Options] for more information.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: True
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Format
+
+Sets the option `Input.Format`.
+
+```yaml
+Type: InputFormat
+Parameter Sets: (All)
+Aliases: Format
+Accepted values: None, Yaml, Json, Detect
+
+Required: False
+Position: Named
+Default value: Detect
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ObjectPath
+
+Sets the option `Input.ObjectPath`.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: ObjectPath
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -LoggingRuleFail
+
+Sets the option `Logging.RuleFail`.
+
+```yaml
+Type: OutcomeLogStream
+Parameter Sets: (All)
+Aliases:
+Accepted values: None, Error, Warning, Information
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -LoggingRulePass
+
+Sets the option `Logging.RulePass`.
+
+```yaml
+Type: OutcomeLogStream
+Parameter Sets: (All)
+Aliases:
+Accepted values: None, Error, Warning, Information
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OutputAs
+
+Sets the option `Output.As`. The `Output.As` option configures the type of results to produce, either detail or summary.
+
+```yaml
+Type: ResultFormat
+Parameter Sets: (All)
+Aliases: As
+Accepted values: Detail, Summary
+
+Required: False
+Position: Named
+Default value: Detail
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OutputFormat
+
+Sets the option `Output.Format`. The `Output.Format` option configures the format that results will be presented in.
+
+```yaml
+Type: OutputFormat
+Parameter Sets: (All)
+Aliases:
+Accepted values: None, Yaml, Json, NUnit3
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+
+Shows what would happen if the cmdlet runs. The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+### PSRule.Configuration.PSRuleOption
+
+When you use the `-PassThru` switch, an options object is returned to the pipeline.
+
+## NOTES
+
+## RELATED LINKS
+
+[New-PSRuleOption](New-PSRuleOption.md)
+
+[about_PSRule_Options]: ../../../concepts/PSRule/en-US/about_PSRule_Options.md

--- a/docs/commands/PSRule/en-US/Set-PSRuleOption.md
+++ b/docs/commands/PSRule/en-US/Set-PSRuleOption.md
@@ -189,7 +189,7 @@ Accept wildcard characters: False
 
 ### -NotProcessedWarning
 
-Sets the option `Execution.NotProcessedWarning`. The `Execution.NotProcessedWarning` option determines if a warning is generated when an object is not processed by any rule. See about_PSRule_Options for more information.
+Sets the `Execution.NotProcessedWarning` option. The `Execution.NotProcessedWarning` option determines if a warning is generated when an object is not processed by any rule. See about_PSRule_Options for more information.
 
 ```yaml
 Type: Boolean
@@ -205,7 +205,7 @@ Accept wildcard characters: False
 
 ### -Format
 
-Sets the option `Input.Format`.
+Sets the `Input.Format` option to configure the input format for when a string is passed in as a target object.
 
 ```yaml
 Type: InputFormat
@@ -222,7 +222,7 @@ Accept wildcard characters: False
 
 ### -ObjectPath
 
-Sets the option `Input.ObjectPath`.
+Sets the `Input.ObjectPath` option to use an object path to use instead of the pipeline object.
 
 ```yaml
 Type: String
@@ -238,7 +238,7 @@ Accept wildcard characters: False
 
 ### -LoggingRuleFail
 
-Sets the option `Logging.RuleFail`.
+Sets the `Logging.RuleFail` option to generate an informational message for each rule fail.
 
 ```yaml
 Type: OutcomeLogStream
@@ -255,7 +255,7 @@ Accept wildcard characters: False
 
 ### -LoggingRulePass
 
-Sets the option `Logging.RulePass`.
+Sets the `Logging.RulePass` option to generate an informational message for each rule pass.
 
 ```yaml
 Type: OutcomeLogStream
@@ -277,7 +277,7 @@ Sets the option `Output.As`. The `Output.As` option configures the type of resul
 ```yaml
 Type: ResultFormat
 Parameter Sets: (All)
-Aliases: As
+Aliases:
 Accepted values: Detail, Summary
 
 Required: False

--- a/docs/commands/PSRule/en-US/Test-PSRuleTarget.md
+++ b/docs/commands/PSRule/en-US/Test-PSRuleTarget.md
@@ -2,6 +2,7 @@
 external help file: PSRule-help.xml
 Module Name: PSRule
 online version: https://berniewhite.github.io/PSRule/commands/PSRule/en-US/Test-PSRuleTarget.html
+schema: 2.0.0
 ---
 
 # Test-PSRuleTarget

--- a/docs/concepts/PSRule/en-US/about_PSRule_Options.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Options.md
@@ -8,7 +8,7 @@ Describes additional options that can be used during rule execution.
 
 ## LONG DESCRIPTION
 
-PSRule lets you use options when calling `Invoke-PSRule` to change how rules are executed. This topic describes what options are available, when to and how to use them.
+PSRule lets you use options when calling cmdlets such as `Invoke-PSRule` and `Test-PSRuleTarget` to change how rules are processed. This topic describes what options are available, when to and how to use them.
 
 The following options are available for use:
 
@@ -29,16 +29,19 @@ The following options are available for use:
 - [Output.Format](#outputformat)
 - [Suppression](#rule-suppression)
 
-Options can be used by:
+Options can be used with the following PSRule cmdlets:
 
-- Using the `-Option` parameter of `Invoke-PSRule` with an object created with `New-PSRuleOption`
-- Using the `-Option` parameter of `Invoke-PSRule` with a hash table
-- Using the `-Option` parameter of `Invoke-PSRule` with a YAML file
-- Configuring the default options file `psrule.yml`
+- Get-PSRule
+- Invoke-PSRule
+- Test-PSRuleTarget
 
-As mentioned above, a options object can be created with `New-PSRuleOption` see cmdlet help for syntax and examples.
+Each of these cmdlets support:
 
-When using a hash table, `@{}`, one or more options can be specified with the `-Option` parameter using a dotted notation.
+- Using the `-Option` parameter with an object created with the `New-PSRuleOption` cmdlet. See cmdlet help for syntax and examples.
+- Using the `-Option` parameter with a hashtable object.
+- Using the `-Option` parameter with a YAML file path.
+
+When using a hashtable object `@{}`, one or more options can be specified as keys using a dotted notation.
 
 For example:
 
@@ -47,11 +50,11 @@ $option = @{ 'execution.languageMode' = 'ConstrainedLanguage' };
 Invoke-PSRule -Path . -Option $option;
 ```
 
-`execution.languageMode` is an example of an option that can be used. Please see the following sections for other options can be used.
+The above example shows how the `execution.languageMode` option as a hashtable key can be used. Continue reading for a full list of options and how each can be used.
 
-Another option is to use an external file, formatted as YAML, instead of having to create an options object manually each time. This YAML file can be used with `Invoke-PSRule` to quickly execute rules in a repeatable way.
+Alternatively, options can be stored in a YAML formatted file and loaded from disk. Storing options as YAML allows different configurations to be loaded in a repeatable way instead of having to create an options object each time.
 
-YAML properties are specified using lower camel case, for example:
+Options are stored as YAML properties using a lower camel case naming convention, for example:
 
 ```yaml
 execution:
@@ -128,7 +131,7 @@ baseline:
 
 When evaluating an object, PSRule extracts a few key properties from the object to help filter rules and display output results. The process of extract these key properties is called _binding_. The properties that PSRule uses for binding can be customized by providing a order list of alternative properties to use. See [`Binding.TargetName`](#bindingtargetname) and [`Binding.TargetType`](#bindingtargettype) for these options.
 
-- By default, custom property binding finds the first matching property by name regardless of case. i.e. `Binding.IgnoreCase` is `true`
+- By default, custom property binding finds the first matching property by name regardless of case. i.e. `Binding.IgnoreCase` is `true`.
 - To change the default, set the `Binding.IgnoreCase` option to `false` and a case sensitive match will be used.
   - Changing this option will affect all custom property bindings, including _TargetName_ and _TargetType_.
 - PSRule also has binding defaults, and an option to use a custom script. Setting this option has no affect on binding defaults or custom scripts.
@@ -136,8 +139,18 @@ When evaluating an object, PSRule extracts a few key properties from the object 
 This option can be specified using:
 
 ```powershell
+# PowerShell: Using the BindingIgnoreCase parameter
+$option = New-PSRuleOption -BindingIgnoreCase $False;
+```
+
+```powershell
 # PowerShell: Using the Binding.IgnoreCase hashtable key
 $option = New-PSRuleOption -Option @{ 'Binding.IgnoreCase' = $False };
+```
+
+```powershell
+# PowerShell: Using the BindingIgnoreCase parameter to set YAML
+Set-PSRuleOption -BindingIgnoreCase $False;
 ```
 
 ```yaml
@@ -169,8 +182,18 @@ The value that PSRule uses for _TargetName_ is configurable. PSRule uses the fol
 Custom property names to use for binding can be specified using:
 
 ```powershell
+# PowerShell: Using the TargetName parameter
+$option = New-PSRuleOption -TargetName 'ResourceName', 'AlternateName';
+```
+
+```powershell
 # PowerShell: Using the Binding.TargetName hashtable key
 $option = New-PSRuleOption -Option @{ 'Binding.TargetName' = 'ResourceName', 'AlternateName' };
+```
+
+```powershell
+# PowerShell: Using the TargetName parameter to set YAML
+Set-PSRuleOption -TargetName 'ResourceName', 'AlternateName';
 ```
 
 ```yaml
@@ -222,9 +245,19 @@ The value that PSRule uses for _TargetType_ is configurable. PSRule uses the fol
 Custom property names to use for binding can be specified using:
 
 ```powershell
+# PowerShell: Using the TargetType parameter
+$option = New-PSRuleOption -TargetType 'ResourceType', 'kind';
+```
+
+```powershell
 # PowerShell: Using the Binding.TargetType hashtable key
 $option = New-PSRuleOption -Option @{ 'Binding.TargetType' = 'ResourceType', 'kind' };
 ```
+
+```powershell
+# PowerShell: Using the TargetType parameter to set YAML
+Set-PSRuleOption -TargetType 'ResourceType', 'kind';
+``
 
 ```yaml
 # YAML: Using the binding/targetType property
@@ -296,8 +329,18 @@ Inconclusive results will:
 The inconclusive warning can be disabled by using:
 
 ```powershell
+# PowerShell: Using the InconclusiveWarning parameter
+$option = New-PSRuleOption -InconclusiveWarning $False;
+```
+
+```powershell
 # PowerShell: Using the Execution.InconclusiveWarning hashtable key
 $option = New-PSRuleOption -Option @{ 'Execution.InconclusiveWarning' = $False };
+```
+
+```powershell
+# PowerShell: Using the InconclusiveWarning parameter to set YAML
+Set-PSRuleOption -InconclusiveWarning $False;
 ```
 
 ```yaml
@@ -320,8 +363,18 @@ Not processed objects will:
 The not processed warning can be disabled by using:
 
 ```powershell
+# PowerShell: Using the NotProcessedWarning parameter
+$option = New-PSRuleOption -NotProcessedWarning $False;
+```
+
+```powershell
 # PowerShell: Using the Execution.NotProcessedWarning hashtable key
 $option = New-PSRuleOption -Option @{ 'Execution.NotProcessedWarning' = $False };
+```
+
+```powershell
+# PowerShell: Using the NotProcessedWarning parameter to set YAML
+Set-PSRuleOption -NotProcessedWarning $False;
 ```
 
 ```yaml
@@ -350,8 +403,18 @@ The following formats are available:
 This option can be specified using:
 
 ```powershell
+# PowerShell: Using the Format parameter
+$option = New-PSRuleOption -Format Yaml;
+```
+
+```powershell
 # PowerShell: Using the Input.Format hashtable key
 $option = New-PSRuleOption -Option @{ 'Input.Format' = 'Yaml' };
+```
+
+```powershell
+# PowerShell: Using the Format parameter to set YAML
+Set-PSRuleOption -Format Yaml;
 ```
 
 ```yaml
@@ -373,8 +436,18 @@ When using `Invoke-PSRule` and `Test-PSRuleTarget` the `-ObjectPath` parameter w
 This option can be specified using:
 
 ```powershell
+# PowerShell: Using the ObjectPath parameter
+$option = New-PSRuleOption -ObjectPath 'items';
+```
+
+```powershell
 # PowerShell: Using the Input.ObjectPath hashtable key
 $option = New-PSRuleOption -Option @{ 'Input.ObjectPath' = 'items' };
+```
+
+```powershell
+# PowerShell: Using the ObjectPath parameter to set YAML
+Set-PSRuleOption -ObjectPath 'items';
 ```
 
 ```yaml
@@ -658,6 +731,7 @@ An online version of this document is available at https://github.com/BernieWhit
 
 - [Invoke-PSRule](https://github.com/BernieWhite/PSRule/blob/master/docs/commands/PSRule/en-US/Invoke-PSRule.md)
 - [New-PSRuleOption](https://github.com/BernieWhite/PSRule/blob/master/docs/commands/PSRule/en-US/New-PSRuleOption.md)
+- [Set-PSRuleOption](https://github.com/BernieWhite/PSRule/blob/master/docs/commands/PSRule/en-US/Set-PSRuleOption.md)
 
 ## KEYWORDS
 

--- a/docs/concepts/PSRule/en-US/about_PSRule_Options.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Options.md
@@ -46,19 +46,25 @@ When using a hashtable object `@{}`, one or more options can be specified as key
 For example:
 
 ```powershell
-$option = @{ 'execution.languageMode' = 'ConstrainedLanguage' };
+$option = @{ 'Output.Format' = 'Yaml' };
 Invoke-PSRule -Path . -Option $option;
 ```
 
-The above example shows how the `execution.languageMode` option as a hashtable key can be used. Continue reading for a full list of options and how each can be used.
+The above example shows how the `Output.Format` option as a hashtable key can be used. Continue reading for a full list of options and how each can be used.
 
 Alternatively, options can be stored in a YAML formatted file and loaded from disk. Storing options as YAML allows different configurations to be loaded in a repeatable way instead of having to create an options object each time.
 
 Options are stored as YAML properties using a lower camel case naming convention, for example:
 
 ```yaml
-execution:
-  languageMode: ConstrainedLanguage
+output:
+  format: Yaml
+```
+
+The `Set-PSRuleOption` cmdlet can be used to set options stored in YAML or the YAML file can be manually edited.
+
+```powershell
+Set-PSRuleOption -OutputFormat Yaml;
 ```
 
 By default PSRule will automatically look for a file named `psrule.yml` in the current working directory. Alternatively, you can specify a YAML file in the `-Option` parameter.
@@ -257,7 +263,7 @@ $option = New-PSRuleOption -Option @{ 'Binding.TargetType' = 'ResourceType', 'ki
 ```powershell
 # PowerShell: Using the TargetType parameter to set YAML
 Set-PSRuleOption -TargetType 'ResourceType', 'kind';
-``
+```
 
 ```yaml
 # YAML: Using the binding/targetType property
@@ -474,8 +480,18 @@ The following streams available:
 This option can be specified using:
 
 ```powershell
+# PowerShell: Using the LoggingRuleFail parameter
+$option = New-PSRuleOption -LoggingRuleFail Error;
+```
+
+```powershell
 # PowerShell: Using the Logging.RuleFail hashtable key
 $option = New-PSRuleOption -Option @{ 'Logging.RuleFail' = 'Error' };
+```
+
+```powershell
+# PowerShell: Using the LoggingRuleFail parameter to set YAML
+Set-PSRuleOption -LoggingRuleFail Error;
 ```
 
 ```yaml
@@ -502,8 +518,18 @@ The following streams available:
 This option can be specified using:
 
 ```powershell
+# PowerShell: Using the LoggingRulePass parameter
+$option = New-PSRuleOption -LoggingRulePass Information;
+```
+
+```powershell
 # PowerShell: Using the Logging.RulePass hashtable key
 $option = New-PSRuleOption -Option @{ 'Logging.RulePass' = 'Information' };
+```
+
+```powershell
+# PowerShell: Using the LoggingRulePass parameter to set YAML
+Set-PSRuleOption -LoggingRulePass Information;
 ```
 
 ```yaml
@@ -526,8 +552,18 @@ The following options are available:
 This option can be specified using:
 
 ```powershell
+# PowerShell: Using the OutputAs parameter
+$option = New-PSRuleOption -OutputAs Yaml;
+```
+
+```powershell
 # PowerShell: Using the Output.As hashtable key
 $option = New-PSRuleOption -Option @{ 'Output.As' = 'Summary' };
+```
+
+```powershell
+# PowerShell: Using the OutputAs parameter to set YAML
+Set-PSRuleOption -OutputAs Yaml;
 ```
 
 ```yaml
@@ -545,12 +581,23 @@ The following format options are available:
 - None - Output is presented as an object using PowerShell defaults. This is the default configuration.
 - Yaml - Output is serialized as YAML.
 - Json - Output is serialized as JSON.
+- NUnit3 - Output is serialized as NUnit3 (XML).
 
 This option can be specified using:
 
 ```powershell
+# PowerShell: Using the OutputFormat parameter
+$option = New-PSRuleOption -OutputFormat Yaml;
+```
+
+```powershell
 # PowerShell: Using the Output.Format hashtable key
 $option = New-PSRuleOption -Option @{ 'Output.Format' = 'Yaml' };
+```
+
+```powershell
+# PowerShell: Using the OutputFormat parameter to set YAML
+Set-PSRuleOption -OutputFormat Yaml;
 ```
 
 ```yaml

--- a/src/PSRule/Configuration/BindingOption.cs
+++ b/src/PSRule/Configuration/BindingOption.cs
@@ -1,11 +1,12 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
 
 namespace PSRule.Configuration
 {
     /// <summary>
     /// Options tht affect property binding of TargetName.
     /// </summary>
-    public sealed class BindingOption
+    public sealed class BindingOption : IEquatable<BindingOption>
     {
         private const bool DEFAULT_IGNORECASE = true;
 
@@ -26,6 +27,32 @@ namespace PSRule.Configuration
             IgnoreCase = option.IgnoreCase;
             TargetName = option.TargetName;
             TargetType = option.TargetType;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj != null &&
+                obj is BindingOption &&
+                Equals(obj as BindingOption);
+        }
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine
+            {
+                int hash = 17;
+                hash = hash * 23 + (IgnoreCase.HasValue ? IgnoreCase.Value.GetHashCode() : 0);
+                hash = hash * 23 + (TargetName != null ? TargetName.GetHashCode() : 0);
+                hash = hash * 23 + (TargetType != null ? TargetType.GetHashCode() : 0);
+                return hash;
+            }
+        }
+
+        public bool Equals(BindingOption other)
+        {
+            return other != null &&
+                IgnoreCase == other.IgnoreCase &&
+                TargetName == other.TargetName &&
+                TargetType == other.TargetType;
         }
 
         /// <summary>

--- a/src/PSRule/Configuration/PSRuleOption.cs
+++ b/src/PSRule/Configuration/PSRuleOption.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using PSRule.Resources;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -17,8 +18,10 @@ namespace PSRule.Configuration
     /// <summary>
     /// A structure that stores PSRule configuration options.
     /// </summary>
-    public sealed class PSRuleOption
+    public sealed class PSRuleOption : IEquatable<PSRuleOption>
     {
+        private const string DEFAULT_FILENAME = "psrule.yaml";
+
         private static readonly PSRuleOption Default = new PSRuleOption
         {
             Binding = BindingOption.Default,
@@ -111,17 +114,24 @@ namespace PSRule.Configuration
             return new PSRuleOption(this);
         }
 
+        public void ToFile(string path)
+        {
+            // Get a rooted file path instead of directory or relative path
+            var filePath = GetFilePath(path: path);
+            File.WriteAllText(path: filePath, contents: ToYaml());
+        }
+
         public static PSRuleOption FromFile(string path, bool silentlyContinue = false)
         {
-            // Ensure that a full path instead of a path relative to PowerShell is used for .NET methods
-            var rootedPath = GetRootedPath(path);
+            // Get a rooted file path instead of directory or relative path
+            var filePath = GetFilePath(path: path);
 
             // Fallback to defaults even if file does not exist when silentlyContinue is true
-            if (!File.Exists(rootedPath))
+            if (!File.Exists(filePath))
             {
                 if (!silentlyContinue)
                 {
-                    throw new FileNotFoundException("", rootedPath);
+                    throw new FileNotFoundException(PSRuleResources.OptionsNotFound, filePath);
                 }
                 else
                 {
@@ -130,7 +140,7 @@ namespace PSRule.Configuration
                 }
             }
 
-            return FromYaml(File.ReadAllText(rootedPath));
+            return FromYaml(yaml: File.ReadAllText(filePath));
         }
 
         public static PSRuleOption FromYaml(string yaml)
@@ -293,6 +303,42 @@ namespace PSRule.Configuration
             return option;
         }
 
+        public override bool Equals(object obj)
+        {
+            return obj != null &&
+                obj is PSRuleOption &&
+                Equals(obj as PSRuleOption);
+        }
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine
+            {
+                int hash = 17;
+                hash = hash * 23 + (Baseline != null ? Baseline.GetHashCode() : 0);
+                hash = hash * 23 + (Binding != null ? Binding.GetHashCode() : 0);
+                hash = hash * 23 + (Execution != null ? Execution.GetHashCode() : 0);
+                hash = hash * 23 + (Input != null ? Input.GetHashCode() : 0);
+                hash = hash * 23 + (Logging != null ? Logging.GetHashCode() : 0);
+                hash = hash * 23 + (Output != null ? Output.GetHashCode() : 0);
+                hash = hash * 23 + (Suppression != null ? Suppression.GetHashCode() : 0);
+                hash = hash * 23 + (Pipeline != null ? Pipeline.GetHashCode() : 0);
+                return hash;
+            }
+        }
+
+        public bool Equals(PSRuleOption other)
+        {
+            return other != null &&
+                Baseline == other.Baseline &&
+                Binding == other.Binding &&
+                Execution == other.Execution &&
+                Input == other.Input &&
+                Logging == other.Logging &&
+                Output == other.Output &&
+                Suppression == other.Suppression &&
+                Pipeline == other.Pipeline;
+        }
+
         /// <summary>
         /// Get a full path instead of a relative path that may be passed from PowerShell.
         /// </summary>
@@ -301,6 +347,12 @@ namespace PSRule.Configuration
         private static string GetRootedPath(string path)
         {
             return Path.IsPathRooted(path) ? path : Path.Combine(GetWorkingPath(), path);
+        }
+
+        private static string GetFilePath(string path)
+        {
+            var rootedPath = GetRootedPath(path);
+            return Path.HasExtension(rootedPath) ? rootedPath : Path.Combine(path, DEFAULT_FILENAME);
         }
     }
 }

--- a/src/PSRule/PSRule.psd1
+++ b/src/PSRule/PSRule.psd1
@@ -75,6 +75,7 @@ FunctionsToExport = @(
     'Test-PSRuleTarget'
     'Get-PSRule'
     'New-PSRuleOption'
+    'Set-PSRuleOption'
     'AllOf'
     'AnyOf'
     'Exists'

--- a/src/PSRule/PSRule.psm1
+++ b/src/PSRule/PSRule.psm1
@@ -460,69 +460,91 @@ function New-PSRuleOption {
 
         # Options
 
-        # Baseline.RuleName
-        # Baseline.Exclude
-        # Baseline.Configuration
-
-        # Sets option Binding.IgnoreCase
+        # Sets the Binding.IgnoreCase option
         [Parameter(Mandatory = $False)]
         [System.Boolean]$BindingIgnoreCase = $True,
 
-        # Sets option Binding.TargetName
+        # Sets the Binding.TargetName option
         [Parameter(Mandatory = $False)]
-        [String[]]$BindingTargetName,
+        [Alias('BindingTargetName')]
+        [String[]]$TargetName,
 
-        # Sets option Binding.TargetType
+        # Sets the Binding.TargetType option
         [Parameter(Mandatory = $False)]
-        [String[]]$BindingTargetType,
+        [Alias('BindingTargetType')]
+        [String[]]$TargetType,
 
-        # Sets option Execution.LanguageMode
+        # Sets the Execution.InconclusiveWarning option
         [Parameter(Mandatory = $False)]
-        [ValidateSet('FullLanguage', 'ConstrainedLanguage')]
-        [PSRule.Configuration.LanguageMode]$ExecutionLanguageMode = 'FullLanguage',
-
-        # Sets option Execution.InconclusiveWarning
-        [Parameter(Mandatory = $False)]
-        [System.Boolean]$ExecutionInconclusiveWarning = $True,
+        [Alias('ExecutionInconclusiveWarning')]
+        [System.Boolean]$InconclusiveWarning = $True,
     
-        # Sets option Execution.NotProcessedWarning
+        # Sets the Execution.NotProcessedWarning option
         [Parameter(Mandatory = $False)]
-        [System.Boolean]$ExecutionNotProcessedWarning = $True,
+        [Alias('ExecutionNotProcessedWarning')]
+        [System.Boolean]$NotProcessedWarning = $True,
 
-        # Sets option Input.Format
+        # Sets the Input.Format option
         [Parameter(Mandatory = $False)]
         [ValidateSet('None', 'Yaml', 'Json', 'Detect')]
-        [Alias('Format')]
-        [PSRule.Configuration.InputFormat]$InputFormat = 'Detect',
+        [Alias('InputFormat')]
+        [PSRule.Configuration.InputFormat]$Format = 'Detect',
 
-        # Sets option Input.ObjectPath
+        # Sets the Input.ObjectPath option
         [Parameter(Mandatory = $False)]
-        [Alias('ObjectPath')]
-        [String]$InputObjectPath = '',
+        [Alias('InputObjectPath')]
+        [String]$ObjectPath = '',
 
-        # Sets option Logging.RuleFail
+        # Sets the Logging.RuleFail option
         [Parameter(Mandatory = $False)]
         [PSRule.Configuration.OutcomeLogStream]$LoggingRuleFail = 'None',
 
-        # Sets option Logging.RulePass
+        # Sets the Logging.RulePass option
         [Parameter(Mandatory = $False)]
         [PSRule.Configuration.OutcomeLogStream]$LoggingRulePass = 'None',
 
-        # Sets option Output.As
+        # Sets the Output.As option
         [Parameter(Mandatory = $False)]
         [ValidateSet('Detail', 'Summary')]
-        [Alias('As')]
         [PSRule.Configuration.ResultFormat]$OutputAs = 'Detail',
 
-        # Sets option Output.Format
+        # Sets the Output.Format option
         [Parameter(Mandatory = $False)]
         [ValidateSet('None', 'Yaml', 'Json', 'NUnit3')]
         [PSRule.Configuration.OutputFormat]$OutputFormat = 'None'
-
-        # Suppression
     )
 
-    end {
+    begin {
+        Write-Verbose -Message "[New-PSRuleOption] BEGIN::";
+
+        # Get parameter options, which will override options from other sources
+        $optionParams = @{ };
+        $optionParams += $PSBoundParameters;
+
+        # Remove invalid parameters
+        if ($optionParams.ContainsKey('Path')) {
+            $optionParams.Remove('Path');
+        }
+
+        if ($optionParams.ContainsKey('Option')) {
+            $optionParams.Remove('Option');
+        }
+
+        if ($optionParams.ContainsKey('BaselineConfiguration')) {
+            $optionParams.Remove('BaselineConfiguration');
+        }
+
+        if ($optionParams.ContainsKey('SuppressTargetName')) {
+            $optionParams.Remove('SuppressTargetName');
+        }
+
+        if ($optionParams.ContainsKey('BindTargetName')) {
+            $optionParams.Remove('BindTargetName');
+        }
+
+        if ($optionParams.ContainsKey('BindTargetType')) {
+            $optionParams.Remove('BindTargetType');
+        }
 
         if ($PSBoundParameters.ContainsKey('Option')) {
             $Option = $Option.Clone();
@@ -535,7 +557,9 @@ function New-PSRuleOption {
             Write-Verbose -Message "Attempting to read: $Path";
             $Option = [PSRule.Configuration.PSRuleOption]::FromFile($Path, $True);
         }
+    }
 
+    end {
         if ($PSBoundParameters.ContainsKey('BaselineConfiguration')) {
             $Option.Baseline.Configuration = $BaselineConfiguration;
         }
@@ -555,75 +579,9 @@ function New-PSRuleOption {
         }
 
         # Options
+        $Option | SetOptions @optionParams -Verbose:$VerbosePreference;
 
-        # Baseline.RuleName
-        # Baseline.Exclude
-        # Baseline.Configuration
-
-        # Sets option Binding.IgnoreCase
-        if ($PSBoundParameters.ContainsKey('BindingIgnoreCase')) {
-            $Option.Binding.IgnoreCase = $BindingIgnoreCase;
-        }
-
-        # Sets option Binding.TargetName
-        if ($PSBoundParameters.ContainsKey('BindingTargetName')) {
-            $Option.Binding.TargetName = $BindingTargetName;
-        }
-
-        # Sets option Binding.TargetType
-        if ($PSBoundParameters.ContainsKey('BindingTargetType')) {
-            $Option.Binding.TargetType = $BindingTargetType;
-        }
-
-
-        # Sets option Execution.LanguageMode
-        if ($PSBoundParameters.ContainsKey('ExecutionLanguageMode')) {
-            $Option.Execution.LanguageMode = $ExecutionLanguageMode;
-        }
-
-        # Sets option Execution.InconclusiveWarning
-        if ($PSBoundParameters.ContainsKey('ExecutionInconclusiveWarning')) {
-            $Option.Execution.InconclusiveWarning = $ExecutionInconclusiveWarning;
-        }
-
-        # Sets option Execution.NotProcessedWarning
-        if ($PSBoundParameters.ContainsKey('ExecutionNotProcessedWarning')) {
-            $Option.Execution.NotProcessedWarning = $ExecutionNotProcessedWarning;
-        }
-
-        # Sets option Input.Format
-        if ($PSBoundParameters.ContainsKey('InputFormat')) {
-            $Option.Input.Format = $InputFormat;
-        }
-
-        # Sets option Input.ObjectPath
-        if ($PSBoundParameters.ContainsKey('InputObjectPath')) {
-            $Option.Input.ObjectPath = $InputObjectPath;
-        }
-
-        # Sets option Logging.RuleFail
-        if ($PSBoundParameters.ContainsKey('LoggingRuleFail')) {
-            $Option.Logging.RuleFail = $LoggingRuleFail;
-        }
-
-        # Sets option Logging.RulePass
-        if ($PSBoundParameters.ContainsKey('LoggingRulePass')) {
-            $Option.Logging.RulePass = $LoggingRulePass;
-        }
-
-        # Sets option Output.As
-        if ($PSBoundParameters.ContainsKey('OutputAs')) {
-            $Option.Output.As = $OutputAs;
-        }
-
-        # Sets option Output.Format
-        if ($PSBoundParameters.ContainsKey('OutputFormat')) {
-            $Option.Output.Format = $OutputFormat;
-        }
-
-        # Suppression
-
-        return $Option;
+        Write-Verbose -Message "[Set-PSRuleOption] END::";
     }
 }
 
@@ -653,10 +611,6 @@ function Set-PSRuleOption {
 
         # Options
 
-        # Baseline.RuleName
-        # Baseline.Exclude
-        # Baseline.Configuration
-
         # Sets the Binding.IgnoreCase option
         [Parameter(Mandatory = $False)]
         [System.Boolean]$BindingIgnoreCase = $True,
@@ -666,52 +620,49 @@ function Set-PSRuleOption {
         [Alias('BindingTargetName')]
         [String[]]$TargetName,
 
-        # Sets option Binding.TargetType
+        # Sets the Binding.TargetType option
         [Parameter(Mandatory = $False)]
         [Alias('BindingTargetType')]
         [String[]]$TargetType,
 
-        # Sets option Execution.InconclusiveWarning
+        # Sets the Execution.InconclusiveWarning option
         [Parameter(Mandatory = $False)]
         [Alias('ExecutionInconclusiveWarning')]
         [System.Boolean]$InconclusiveWarning = $True,
     
-        # Sets option Execution.NotProcessedWarning
+        # Sets the Execution.NotProcessedWarning option
         [Parameter(Mandatory = $False)]
         [Alias('ExecutionNotProcessedWarning')]
         [System.Boolean]$NotProcessedWarning = $True,
 
-        # Sets option Input.Format
+        # Sets the Input.Format option
         [Parameter(Mandatory = $False)]
         [ValidateSet('None', 'Yaml', 'Json', 'Detect')]
         [Alias('InputFormat')]
         [PSRule.Configuration.InputFormat]$Format = 'Detect',
 
-        # Sets option Input.ObjectPath
+        # Sets the Input.ObjectPath option
         [Parameter(Mandatory = $False)]
         [Alias('InputObjectPath')]
         [String]$ObjectPath = '',
 
-        # Sets option Logging.RuleFail
+        # Sets the Logging.RuleFail option
         [Parameter(Mandatory = $False)]
         [PSRule.Configuration.OutcomeLogStream]$LoggingRuleFail = 'None',
 
-        # Sets option Logging.RulePass
+        # Sets the Logging.RulePass option
         [Parameter(Mandatory = $False)]
         [PSRule.Configuration.OutcomeLogStream]$LoggingRulePass = 'None',
 
-        # Sets option Output.As
+        # Sets the Output.As option
         [Parameter(Mandatory = $False)]
         [ValidateSet('Detail', 'Summary')]
-        [Alias('As')]
         [PSRule.Configuration.ResultFormat]$OutputAs = 'Detail',
 
-        # Sets option Output.Format
+        # Sets the Output.Format option
         [Parameter(Mandatory = $False)]
         [ValidateSet('None', 'Yaml', 'Json', 'NUnit3')]
         [PSRule.Configuration.OutputFormat]$OutputFormat = 'None'
-
-        # Suppression
     )
 
     begin {
@@ -721,19 +672,40 @@ function Set-PSRuleOption {
         $optionParams = @{ };
         $optionParams += $PSBoundParameters;
 
-        if ($PSBoundParameters.ContainsKey('Path')) {
-            $optionParams['Path'] = $Path;
+        # Remove invalid parameters
+        if ($optionParams.ContainsKey('Path')) {
+            $optionParams.Remove('Path');
         }
 
-        # Remove PassThru which is not valid on New-PSRuleOption
+        if ($optionParams.ContainsKey('Option')) {
+            $optionParams.Remove('Option');
+        }
+
         if ($optionParams.ContainsKey('PassThru')) {
             $optionParams.Remove('PassThru');
+        }
+
+        if ($optionParams.ContainsKey('Force')) {
+            $optionParams.Remove('Force');
+        }
+
+        if ($optionParams.ContainsKey('Overwrite')) {
+            $optionParams.Remove('Overwrite');
+        }
+
+        # Build options object
+        if ($PSBoundParameters.ContainsKey('Option')) {
+            $Option = $Option.Clone();
+        }
+        else {
+            Write-Verbose -Message "[Set-PSRuleOption] -- Attempting to read: $Path";
+            $Option = [PSRule.Configuration.PSRuleOption]::FromFile($Path, $False);
         }
     }
 
     process {
         try {
-            $result = New-PSRuleOption @optionParams;
+            $result = $Option | SetOptions @optionParams;
             if ($PassThru) {
                 $result;
             }
@@ -1018,6 +990,131 @@ function GetFilePath {
         }
 
         $builder.Build();
+    }
+}
+
+function SetOptions {
+    [CmdletBinding()]
+    [OutputType([PSRule.Configuration.PSRuleOption])]
+    param (
+        [Parameter(Mandatory = $True, ValueFromPipeline = $True)]
+        [PSRule.Configuration.PSRuleOption]$InputObject,
+
+        # Options
+
+        # Sets the Binding.IgnoreCase option
+        [Parameter(Mandatory = $False)]
+        [System.Boolean]$BindingIgnoreCase = $True,
+
+        # Sets the Binding.TargetName option
+        [Parameter(Mandatory = $False)]
+        [Alias('BindingTargetName')]
+        [String[]]$TargetName,
+
+        # Sets the Binding.TargetType option
+        [Parameter(Mandatory = $False)]
+        [Alias('BindingTargetType')]
+        [String[]]$TargetType,
+
+        # Sets the Execution.InconclusiveWarning option
+        [Parameter(Mandatory = $False)]
+        [Alias('ExecutionInconclusiveWarning')]
+        [System.Boolean]$InconclusiveWarning = $True,
+    
+        # Sets the Execution.NotProcessedWarning option
+        [Parameter(Mandatory = $False)]
+        [Alias('ExecutionNotProcessedWarning')]
+        [System.Boolean]$NotProcessedWarning = $True,
+
+        # Sets the Input.Format option
+        [Parameter(Mandatory = $False)]
+        [ValidateSet('None', 'Yaml', 'Json', 'Detect')]
+        [Alias('InputFormat')]
+        [PSRule.Configuration.InputFormat]$Format = 'Detect',
+
+        # Sets the Input.ObjectPath option
+        [Parameter(Mandatory = $False)]
+        [Alias('InputObjectPath')]
+        [String]$ObjectPath = '',
+
+        # Sets the Logging.RuleFail option
+        [Parameter(Mandatory = $False)]
+        [PSRule.Configuration.OutcomeLogStream]$LoggingRuleFail = 'None',
+
+        # Sets the Logging.RulePass option
+        [Parameter(Mandatory = $False)]
+        [PSRule.Configuration.OutcomeLogStream]$LoggingRulePass = 'None',
+
+        # Sets the Output.As option
+        [Parameter(Mandatory = $False)]
+        [ValidateSet('Detail', 'Summary')]
+        [PSRule.Configuration.ResultFormat]$OutputAs = 'Detail',
+
+        # Sets the Output.Format option
+        [Parameter(Mandatory = $False)]
+        [ValidateSet('None', 'Yaml', 'Json', 'NUnit3')]
+        [PSRule.Configuration.OutputFormat]$OutputFormat = 'None'
+    )
+
+    process {
+        # Options
+
+        # Sets option Binding.IgnoreCase
+        if ($PSBoundParameters.ContainsKey('BindingIgnoreCase')) {
+            $Option.Binding.IgnoreCase = $BindingIgnoreCase;
+        }
+
+        # Sets option Binding.TargetName
+        if ($PSBoundParameters.ContainsKey('TargetName')) {
+            $Option.Binding.TargetName = $TargetName;
+        }
+
+        # Sets option Binding.TargetType
+        if ($PSBoundParameters.ContainsKey('TargetType')) {
+            $Option.Binding.TargetType = $TargetType;
+        }
+
+        # Sets option Execution.InconclusiveWarning
+        if ($PSBoundParameters.ContainsKey('InconclusiveWarning')) {
+            $Option.Execution.InconclusiveWarning = $InconclusiveWarning;
+        }
+
+        # Sets option Execution.NotProcessedWarning
+        if ($PSBoundParameters.ContainsKey('NotProcessedWarning')) {
+            $Option.Execution.NotProcessedWarning = $NotProcessedWarning;
+        }
+
+        # Sets option Input.Format
+        if ($PSBoundParameters.ContainsKey('Format')) {
+            $Option.Input.Format = $Format;
+        }
+
+        # Sets option Input.ObjectPath
+        if ($PSBoundParameters.ContainsKey('ObjectPath')) {
+            $Option.Input.ObjectPath = $ObjectPath;
+        }
+
+        # Sets option Logging.RuleFail
+        if ($PSBoundParameters.ContainsKey('LoggingRuleFail')) {
+            $Option.Logging.RuleFail = $LoggingRuleFail;
+        }
+
+        # Sets option Logging.RulePass
+        if ($PSBoundParameters.ContainsKey('LoggingRulePass')) {
+            $Option.Logging.RulePass = $LoggingRulePass;
+        }
+
+        # Sets option Output.As
+        if ($PSBoundParameters.ContainsKey('OutputAs')) {
+            $Option.Output.As = $OutputAs;
+        }
+
+        # Sets option Output.Format
+        if ($PSBoundParameters.ContainsKey('OutputFormat')) {
+            $Option.Output.Format = $OutputFormat;
+        }
+
+        return $Option;
     }
 }
 

--- a/src/PSRule/PSRule.psm1
+++ b/src/PSRule/PSRule.psm1
@@ -435,11 +435,14 @@ function Get-PSRule {
 
 # .ExternalHelp PSRule-Help.xml
 function New-PSRuleOption {
-
     [CmdletBinding()]
     [OutputType([PSRule.Configuration.PSRuleOption])]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Creates an in memory object only')]
     param (
+        [Parameter(Position = 0, Mandatory = $False)]
+        [PSDefaultValue(Help = '.\ps-rule.yml')]
+        [String]$Path = $PWD,
+
         [Parameter(Mandatory = $False)]
         [PSRule.Configuration.PSRuleOption]$Option,
 
@@ -455,29 +458,81 @@ function New-PSRuleOption {
         [Parameter(Mandatory = $False)]
         [PSRule.Configuration.BindTargetName[]]$BindTargetType,
 
+        # Options
+
+        # Baseline.RuleName
+        # Baseline.Exclude
+        # Baseline.Configuration
+
+        # Sets option Binding.IgnoreCase
         [Parameter(Mandatory = $False)]
-        [PSDefaultValue(Help = '.\psrule.yml')]
-        [String]$Path = '.\psrule.yml'
+        [System.Boolean]$BindingIgnoreCase = $True,
+
+        # Sets option Binding.TargetName
+        [Parameter(Mandatory = $False)]
+        [String[]]$BindingTargetName,
+
+        # Sets option Binding.TargetType
+        [Parameter(Mandatory = $False)]
+        [String[]]$BindingTargetType,
+
+        # Sets option Execution.LanguageMode
+        [Parameter(Mandatory = $False)]
+        [ValidateSet('FullLanguage', 'ConstrainedLanguage')]
+        [PSRule.Configuration.LanguageMode]$ExecutionLanguageMode = 'FullLanguage',
+
+        # Sets option Execution.InconclusiveWarning
+        [Parameter(Mandatory = $False)]
+        [System.Boolean]$ExecutionInconclusiveWarning = $True,
+    
+        # Sets option Execution.NotProcessedWarning
+        [Parameter(Mandatory = $False)]
+        [System.Boolean]$ExecutionNotProcessedWarning = $True,
+
+        # Sets option Input.Format
+        [Parameter(Mandatory = $False)]
+        [ValidateSet('None', 'Yaml', 'Json', 'Detect')]
+        [Alias('Format')]
+        [PSRule.Configuration.InputFormat]$InputFormat = 'Detect',
+
+        # Sets option Input.ObjectPath
+        [Parameter(Mandatory = $False)]
+        [Alias('ObjectPath')]
+        [String]$InputObjectPath = '',
+
+        # Sets option Logging.RuleFail
+        [Parameter(Mandatory = $False)]
+        [PSRule.Configuration.OutcomeLogStream]$LoggingRuleFail = 'None',
+
+        # Sets option Logging.RulePass
+        [Parameter(Mandatory = $False)]
+        [PSRule.Configuration.OutcomeLogStream]$LoggingRulePass = 'None',
+
+        # Sets option Output.As
+        [Parameter(Mandatory = $False)]
+        [ValidateSet('Detail', 'Summary')]
+        [Alias('As')]
+        [PSRule.Configuration.ResultFormat]$OutputAs = 'Detail',
+
+        # Sets option Output.Format
+        [Parameter(Mandatory = $False)]
+        [ValidateSet('None', 'Yaml', 'Json', 'NUnit3')]
+        [PSRule.Configuration.OutputFormat]$OutputFormat = 'None'
+
+        # Suppression
     )
 
-    process {
+    end {
 
         if ($PSBoundParameters.ContainsKey('Option')) {
             $Option = $Option.Clone();
         }
         elseif ($PSBoundParameters.ContainsKey('Path')) {
-
-            if (!(Test-Path -Path $Path)) {
-
-            }
-
-            $Path = Resolve-Path -Path $Path;
-
-            $Option = [PSRule.Configuration.PSRuleOption]::FromFile($Path);
+            Write-Verbose -Message "Attempting to read: $Path";
+            $Option = [PSRule.Configuration.PSRuleOption]::FromFile($Path, $False);
         }
         else {
             Write-Verbose -Message "Attempting to read: $Path";
-
             $Option = [PSRule.Configuration.PSRuleOption]::FromFile($Path, $True);
         }
 
@@ -499,7 +554,200 @@ function New-PSRuleOption {
             $Option.Pipeline.BindTargetType.AddRange($BindTargetType);
         }
 
+        # Options
+
+        # Baseline.RuleName
+        # Baseline.Exclude
+        # Baseline.Configuration
+
+        # Sets option Binding.IgnoreCase
+        if ($PSBoundParameters.ContainsKey('BindingIgnoreCase')) {
+            $Option.Binding.IgnoreCase = $BindingIgnoreCase;
+        }
+
+        # Sets option Binding.TargetName
+        if ($PSBoundParameters.ContainsKey('BindingTargetName')) {
+            $Option.Binding.TargetName = $BindingTargetName;
+        }
+
+        # Sets option Binding.TargetType
+        if ($PSBoundParameters.ContainsKey('BindingTargetType')) {
+            $Option.Binding.TargetType = $BindingTargetType;
+        }
+
+
+        # Sets option Execution.LanguageMode
+        if ($PSBoundParameters.ContainsKey('ExecutionLanguageMode')) {
+            $Option.Execution.LanguageMode = $ExecutionLanguageMode;
+        }
+
+        # Sets option Execution.InconclusiveWarning
+        if ($PSBoundParameters.ContainsKey('ExecutionInconclusiveWarning')) {
+            $Option.Execution.InconclusiveWarning = $ExecutionInconclusiveWarning;
+        }
+
+        # Sets option Execution.NotProcessedWarning
+        if ($PSBoundParameters.ContainsKey('ExecutionNotProcessedWarning')) {
+            $Option.Execution.NotProcessedWarning = $ExecutionNotProcessedWarning;
+        }
+
+        # Sets option Input.Format
+        if ($PSBoundParameters.ContainsKey('InputFormat')) {
+            $Option.Input.Format = $InputFormat;
+        }
+
+        # Sets option Input.ObjectPath
+        if ($PSBoundParameters.ContainsKey('InputObjectPath')) {
+            $Option.Input.ObjectPath = $InputObjectPath;
+        }
+
+        # Sets option Logging.RuleFail
+        if ($PSBoundParameters.ContainsKey('LoggingRuleFail')) {
+            $Option.Logging.RuleFail = $LoggingRuleFail;
+        }
+
+        # Sets option Logging.RulePass
+        if ($PSBoundParameters.ContainsKey('LoggingRulePass')) {
+            $Option.Logging.RulePass = $LoggingRulePass;
+        }
+
+        # Sets option Output.As
+        if ($PSBoundParameters.ContainsKey('OutputAs')) {
+            $Option.Output.As = $OutputAs;
+        }
+
+        # Sets option Output.Format
+        if ($PSBoundParameters.ContainsKey('OutputFormat')) {
+            $Option.Output.Format = $OutputFormat;
+        }
+
+        # Suppression
+
         return $Option;
+    }
+}
+
+# .ExternalHelp PSRule-Help.xml
+function Set-PSRuleOption {
+    [CmdletBinding(SupportsShouldProcess = $True)]
+    [OutputType([PSRule.Configuration.PSRuleOption])]
+    param (
+        # The path to a YAML file where options will be set
+        [Parameter(Position = 0, Mandatory = $False)]
+        [PSDefaultValue(Help = '.\ps-rule.yml')]
+        [String]$Path = $PWD,
+
+        [Parameter(Mandatory = $False, ValueFromPipeline = $True)]
+        [PSRule.Configuration.PSRuleOption]$Option,
+
+        [Parameter(Mandatory = $False)]
+        [Switch]$PassThru = $False,
+
+        # Force creation of directory path for Path parameter
+        [Parameter(Mandatory = $False)]
+        [Switch]$Force = $False,
+
+        # Overwrite YAML files that contain comments
+        [Parameter(Mandatory = $False)]
+        [Switch]$Overwrite = $False,
+
+        # Options
+
+        # Baseline.RuleName
+        # Baseline.Exclude
+        # Baseline.Configuration
+
+        # Sets the Binding.IgnoreCase option
+        [Parameter(Mandatory = $False)]
+        [System.Boolean]$BindingIgnoreCase = $True,
+
+        # Sets the Binding.TargetName option
+        [Parameter(Mandatory = $False)]
+        [Alias('BindingTargetName')]
+        [String[]]$TargetName,
+
+        # Sets option Binding.TargetType
+        [Parameter(Mandatory = $False)]
+        [Alias('BindingTargetType')]
+        [String[]]$TargetType,
+
+        # Sets option Execution.InconclusiveWarning
+        [Parameter(Mandatory = $False)]
+        [Alias('ExecutionInconclusiveWarning')]
+        [System.Boolean]$InconclusiveWarning = $True,
+    
+        # Sets option Execution.NotProcessedWarning
+        [Parameter(Mandatory = $False)]
+        [Alias('ExecutionNotProcessedWarning')]
+        [System.Boolean]$NotProcessedWarning = $True,
+
+        # Sets option Input.Format
+        [Parameter(Mandatory = $False)]
+        [ValidateSet('None', 'Yaml', 'Json', 'Detect')]
+        [Alias('InputFormat')]
+        [PSRule.Configuration.InputFormat]$Format = 'Detect',
+
+        # Sets option Input.ObjectPath
+        [Parameter(Mandatory = $False)]
+        [Alias('InputObjectPath')]
+        [String]$ObjectPath = '',
+
+        # Sets option Logging.RuleFail
+        [Parameter(Mandatory = $False)]
+        [PSRule.Configuration.OutcomeLogStream]$LoggingRuleFail = 'None',
+
+        # Sets option Logging.RulePass
+        [Parameter(Mandatory = $False)]
+        [PSRule.Configuration.OutcomeLogStream]$LoggingRulePass = 'None',
+
+        # Sets option Output.As
+        [Parameter(Mandatory = $False)]
+        [ValidateSet('Detail', 'Summary')]
+        [Alias('As')]
+        [PSRule.Configuration.ResultFormat]$OutputAs = 'Detail',
+
+        # Sets option Output.Format
+        [Parameter(Mandatory = $False)]
+        [ValidateSet('None', 'Yaml', 'Json', 'NUnit3')]
+        [PSRule.Configuration.OutputFormat]$OutputFormat = 'None'
+
+        # Suppression
+    )
+
+    begin {
+        Write-Verbose -Message "[Set-PSRuleOption] BEGIN::";
+
+        # Get parameter options, which will override options from other sources
+        $optionParams = @{ };
+        $optionParams += $PSBoundParameters;
+
+        if ($PSBoundParameters.ContainsKey('Path')) {
+            $optionParams['Path'] = $Path;
+        }
+
+        # Remove PassThru which is not valid on New-PSRuleOption
+        if ($optionParams.ContainsKey('PassThru')) {
+            $optionParams.Remove('PassThru');
+        }
+    }
+
+    process {
+        try {
+            $result = New-PSRuleOption @optionParams;
+            if ($PassThru) {
+                $result;
+            }
+            else {
+                $result.ToFile($Path);
+            }
+        }
+        finally {
+
+        }
+    }
+
+    end {
+        Write-Verbose -Message "[Set-PSRuleOption] END::";
     }
 }
 
@@ -844,6 +1092,13 @@ InitEditorServices;
 # Export module
 #
 
-Export-ModuleMember -Function 'Rule','Invoke-PSRule','Test-PSRuleTarget','Get-PSRule','New-PSRuleOption';
+Export-ModuleMember -Function @(
+    'Rule'
+    'Invoke-PSRule'
+    'Test-PSRuleTarget'
+    'Get-PSRule'
+    'New-PSRuleOption'
+    'Set-PSRuleOption'
+)
 
 # EOM

--- a/src/PSRule/Resources/PSRuleResources.Designer.cs
+++ b/src/PSRule/Resources/PSRuleResources.Designer.cs
@@ -19,7 +19,7 @@ namespace PSRule.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class PSRuleResources {
@@ -66,6 +66,15 @@ namespace PSRule.Resources {
         internal static string ObjectNotProcessed {
             get {
                 return ResourceManager.GetString("ObjectNotProcessed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Options file does not exist..
+        /// </summary>
+        internal static string OptionsNotFound {
+            get {
+                return ResourceManager.GetString("OptionsNotFound", resourceCulture);
             }
         }
         

--- a/src/PSRule/Resources/PSRuleResources.resx
+++ b/src/PSRule/Resources/PSRuleResources.resx
@@ -120,6 +120,10 @@
   <data name="ObjectNotProcessed" xml:space="preserve">
     <value>Target object '{0}' has not been processed because no matching rules were found.</value>
   </data>
+  <data name="OptionsNotFound" xml:space="preserve">
+    <value>Options file does not exist.</value>
+    <comment>Occurs when explicit path to a YAML file is specified and doesn't exist.</comment>
+  </data>
   <data name="OutcomeRuleFail" xml:space="preserve">
     <value>[FAIL] -- {0}:: Reported for '{1}'</value>
   </data>

--- a/src/PSRule/en-AU/PSRule.Resources.psd1
+++ b/src/PSRule/en-AU/PSRule.Resources.psd1
@@ -3,5 +3,6 @@
 ConvertFrom-StringData @'
 ###PSLOC
 PathNotFound=Path not found
+YamlContainsComments=The YAML options file contains comments. Comments will be lost if you choose to continue. To overwrite comments use the -AllowClobber switch.
 ###PSLOC
 '@

--- a/src/PSRule/en-US/PSRule.Resources.psd1
+++ b/src/PSRule/en-US/PSRule.Resources.psd1
@@ -3,5 +3,6 @@
 ConvertFrom-StringData @'
 ###PSLOC
 PathNotFound=Path not found
+YamlContainsComments=The YAML options file contains comments. Comments will be lost if you choose to continue. To overwrite comments use the -AllowClobber switch.
 ###PSLOC
 '@

--- a/tests/PSRule.Tests/PSRule.Options.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Options.Tests.ps1
@@ -167,7 +167,7 @@ Describe 'New-PSRuleOption' -Tag 'Option','New-PSRuleOption' {
         }
 
         It 'from parameter' {
-            $option = New-PSRuleOption -BindingTargetName 'ResourceName', 'AlternateName' -Path $emptyOptionsFilePath;
+            $option = New-PSRuleOption -TargetName 'ResourceName', 'AlternateName' -Path $emptyOptionsFilePath;
             $option.Binding.TargetName | Should -BeIn 'ResourceName', 'AlternateName';
         }
     }
@@ -204,7 +204,7 @@ Describe 'New-PSRuleOption' -Tag 'Option','New-PSRuleOption' {
         }
 
         It 'from parameter' {
-            $option = New-PSRuleOption -BindingTargetType 'ResourceType', 'Kind' -Path $emptyOptionsFilePath;
+            $option = New-PSRuleOption -TargetType 'ResourceType', 'Kind' -Path $emptyOptionsFilePath;
             $option.Binding.TargetType | Should -BeIn 'ResourceType', 'Kind';
         }
     }
@@ -222,11 +222,6 @@ Describe 'New-PSRuleOption' -Tag 'Option','New-PSRuleOption' {
 
         It 'from YAML' {
             $option = New-PSRuleOption -Option (Join-Path -Path $here -ChildPath 'PSRule.Tests.yml');
-            $option.Execution.LanguageMode | Should -Be 'ConstrainedLanguage';
-        }
-
-        It 'from parameter' {
-            $option = New-PSRuleOption -ExecutionLanguageMode 'ConstrainedLanguage' -Path $emptyOptionsFilePath;
             $option.Execution.LanguageMode | Should -Be 'ConstrainedLanguage';
         }
     }
@@ -248,7 +243,7 @@ Describe 'New-PSRuleOption' -Tag 'Option','New-PSRuleOption' {
         }
 
         It 'from parameter' {
-            $option = New-PSRuleOption -ExecutionInconclusiveWarning $False -Path $emptyOptionsFilePath;
+            $option = New-PSRuleOption -InconclusiveWarning $False -Path $emptyOptionsFilePath;
             $option.Execution.InconclusiveWarning | Should -Be $False;
         }
     }
@@ -270,7 +265,7 @@ Describe 'New-PSRuleOption' -Tag 'Option','New-PSRuleOption' {
         }
 
         It 'from parameter' {
-            $option = New-PSRuleOption -ExecutionNotProcessedWarning $False -Path $emptyOptionsFilePath;
+            $option = New-PSRuleOption -NotProcessedWarning $False -Path $emptyOptionsFilePath;
             $option.Execution.NotProcessedWarning | Should -Be $False;
         }
     }
@@ -292,7 +287,7 @@ Describe 'New-PSRuleOption' -Tag 'Option','New-PSRuleOption' {
         }
 
         It 'from parameter' {
-            $option = New-PSRuleOption -InputFormat 'Yaml' -Path $emptyOptionsFilePath;
+            $option = New-PSRuleOption -Format 'Yaml' -Path $emptyOptionsFilePath;
             $option.Input.Format | Should -Be 'Yaml';
         }
     }
@@ -314,7 +309,7 @@ Describe 'New-PSRuleOption' -Tag 'Option','New-PSRuleOption' {
         }
 
         It 'from parameter' {
-            $option = New-PSRuleOption -InputObjectPath 'items' -Path $emptyOptionsFilePath;
+            $option = New-PSRuleOption -ObjectPath 'items' -Path $emptyOptionsFilePath;
             $option.Input.ObjectPath | Should -Be 'items';
         }
     }
@@ -437,10 +432,6 @@ Describe 'Set-PSRuleOption' -Tag 'Option','Set-PSRuleOption' {
         PassThru = $True
     }
 
-    # Baseline.RuleName
-    # Baseline.Exclude
-    # Baseline.Configuration
-
     Context 'Read Binding.IgnoreCase' {
         It 'from parameter' {
             $option = Set-PSRuleOption -BindingIgnoreCase $False @optionParams;
@@ -450,49 +441,42 @@ Describe 'Set-PSRuleOption' -Tag 'Option','Set-PSRuleOption' {
 
     Context 'Read Binding.TargetName' {
         It 'from parameter' {
-            $option = Set-PSRuleOption -BindingTargetName 'ResourceName', 'AlternateName' @optionParams;
+            $option = Set-PSRuleOption -TargetName 'ResourceName', 'AlternateName' @optionParams;
             $option.Binding.TargetName | Should -BeIn 'ResourceName', 'AlternateName';
         }
     }
 
     Context 'Read Binding.TargetType' {
         It 'from parameter' {
-            $option = Set-PSRuleOption -BindingTargetType 'ResourceType', 'Kind' @optionParams;
+            $option = Set-PSRuleOption -TargetType 'ResourceType', 'Kind' @optionParams;
             $option.Binding.TargetType | Should -BeIn 'ResourceType', 'Kind';
-        }
-    }
-
-    Context 'Read Execution.LanguageMode' {
-        It 'from parameter' {
-            $option = Set-PSRuleOption -ExecutionLanguageMode 'ConstrainedLanguage' @optionParams;
-            $option.Execution.LanguageMode | Should -Be 'ConstrainedLanguage';
         }
     }
 
     Context 'Read Execution.InconclusiveWarning' {
         It 'from parameter' {
-            $option = Set-PSRuleOption -ExecutionInconclusiveWarning $False @optionParams;
+            $option = Set-PSRuleOption -InconclusiveWarning $False @optionParams;
             $option.Execution.InconclusiveWarning | Should -Be $False;
         }
     }
 
     Context 'Read Execution.NotProcessedWarning' {
         It 'from parameter' {
-            $option = Set-PSRuleOption -ExecutionNotProcessedWarning $False @optionParams;
+            $option = Set-PSRuleOption -NotProcessedWarning $False @optionParams;
             $option.Execution.NotProcessedWarning | Should -Be $False;
         }
     }
 
     Context 'Read Input.Format' {
         It 'from parameter' {
-            $option = Set-PSRuleOption -InputFormat 'Yaml' @optionParams;
+            $option = Set-PSRuleOption -Format 'Yaml' @optionParams;
             $option.Input.Format | Should -Be 'Yaml';
         }
     }
 
     Context 'Read Input.ObjectPath' {
         It 'from parameter' {
-            $option = Set-PSRuleOption -InputObjectPath 'items' @optionParams;
+            $option = Set-PSRuleOption -ObjectPath 'items' @optionParams;
             $option.Input.ObjectPath | Should -Be 'items';
         }
     }
@@ -524,8 +508,6 @@ Describe 'Set-PSRuleOption' -Tag 'Option','Set-PSRuleOption' {
             $option.Output.Format | Should -Be 'Yaml';
         }
     }
-    
-    # Suppression
 }
 
 #endregion Set-PSRuleOption

--- a/tests/PSRule.Tests/PSRule.Options.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Options.Tests.ps1
@@ -28,6 +28,8 @@ $Null = New-Item -Path $outputPath -ItemType Directory -Force;
 #region New-PSRuleOption
 
 Describe 'New-PSRuleOption' -Tag 'Option','New-PSRuleOption' {
+    $emptyOptionsFilePath = (Join-Path -Path $here -ChildPath 'PSRule.Tests4.yml');
+
     Context 'Read Baseline.RuleName' {
         It 'from default' {
             $option = New-PSRuleOption;
@@ -126,6 +128,11 @@ Describe 'New-PSRuleOption' -Tag 'Option','New-PSRuleOption' {
             $option = New-PSRuleOption -Option (Join-Path -Path $here -ChildPath 'PSRule.Tests.yml');
             $option.Binding.IgnoreCase | Should -Be $False;
         }
+
+        It 'from parameter' {
+            $option = New-PSRuleOption -BindingIgnoreCase $False -Path $emptyOptionsFilePath;
+            $option.Binding.IgnoreCase | Should -Be $False;
+        }
     }
 
     Context 'Read Binding.TargetName' {
@@ -157,6 +164,11 @@ Describe 'New-PSRuleOption' -Tag 'Option','New-PSRuleOption' {
             # With flat single item
             $option = New-PSRuleOption -Option (Join-Path -Path $here -ChildPath 'PSRule.Tests3.yml');
             $option.Binding.TargetName | Should -BeIn 'ResourceName';
+        }
+
+        It 'from parameter' {
+            $option = New-PSRuleOption -BindingTargetName 'ResourceName', 'AlternateName' -Path $emptyOptionsFilePath;
+            $option.Binding.TargetName | Should -BeIn 'ResourceName', 'AlternateName';
         }
     }
 
@@ -190,22 +202,32 @@ Describe 'New-PSRuleOption' -Tag 'Option','New-PSRuleOption' {
             $option = New-PSRuleOption -Option (Join-Path -Path $here -ChildPath 'PSRule.Tests3.yml');
             $option.Binding.TargetType | Should -BeIn 'ResourceType';
         }
+
+        It 'from parameter' {
+            $option = New-PSRuleOption -BindingTargetType 'ResourceType', 'Kind' -Path $emptyOptionsFilePath;
+            $option.Binding.TargetType | Should -BeIn 'ResourceType', 'Kind';
+        }
     }
 
     Context 'Read Execution.LanguageMode' {
         It 'from default' {
             $option = New-PSRuleOption;
-            $option.Execution.LanguageMode | Should -Be FullLanguage;
+            $option.Execution.LanguageMode | Should -Be 'FullLanguage';
         }
 
         It 'from Hashtable' {
             $option = New-PSRuleOption -Option @{ 'Execution.LanguageMode' = 'ConstrainedLanguage' };
-            $option.Execution.LanguageMode | Should -Be ConstrainedLanguage;
+            $option.Execution.LanguageMode | Should -Be 'ConstrainedLanguage';
         }
 
         It 'from YAML' {
             $option = New-PSRuleOption -Option (Join-Path -Path $here -ChildPath 'PSRule.Tests.yml');
-            $option.Execution.LanguageMode | Should -Be ConstrainedLanguage
+            $option.Execution.LanguageMode | Should -Be 'ConstrainedLanguage';
+        }
+
+        It 'from parameter' {
+            $option = New-PSRuleOption -ExecutionLanguageMode 'ConstrainedLanguage' -Path $emptyOptionsFilePath;
+            $option.Execution.LanguageMode | Should -Be 'ConstrainedLanguage';
         }
     }
 
@@ -222,6 +244,11 @@ Describe 'New-PSRuleOption' -Tag 'Option','New-PSRuleOption' {
 
         It 'from YAML' {
             $option = New-PSRuleOption -Option (Join-Path -Path $here -ChildPath 'PSRule.Tests.yml');
+            $option.Execution.InconclusiveWarning | Should -Be $False;
+        }
+
+        It 'from parameter' {
+            $option = New-PSRuleOption -ExecutionInconclusiveWarning $False -Path $emptyOptionsFilePath;
             $option.Execution.InconclusiveWarning | Should -Be $False;
         }
     }
@@ -241,6 +268,11 @@ Describe 'New-PSRuleOption' -Tag 'Option','New-PSRuleOption' {
             $option = New-PSRuleOption -Option (Join-Path -Path $here -ChildPath 'PSRule.Tests.yml');
             $option.Execution.NotProcessedWarning | Should -Be $False;
         }
+
+        It 'from parameter' {
+            $option = New-PSRuleOption -ExecutionNotProcessedWarning $False -Path $emptyOptionsFilePath;
+            $option.Execution.NotProcessedWarning | Should -Be $False;
+        }
     }
 
     Context 'Read Input.Format' {
@@ -251,12 +283,17 @@ Describe 'New-PSRuleOption' -Tag 'Option','New-PSRuleOption' {
 
         It 'from Hashtable' {
             $option = New-PSRuleOption -Option @{ 'Input.Format' = 'Yaml' };
-            $option.Input.Format | Should -Be Yaml;
+            $option.Input.Format | Should -Be 'Yaml';
         }
 
         It 'from YAML' {
             $option = New-PSRuleOption -Option (Join-Path -Path $here -ChildPath 'PSRule.Tests.yml');
-            $option.Input.Format | Should -Be Yaml;
+            $option.Input.Format | Should -Be 'Yaml';
+        }
+
+        It 'from parameter' {
+            $option = New-PSRuleOption -InputFormat 'Yaml' -Path $emptyOptionsFilePath;
+            $option.Input.Format | Should -Be 'Yaml';
         }
     }
 
@@ -275,6 +312,11 @@ Describe 'New-PSRuleOption' -Tag 'Option','New-PSRuleOption' {
             $option = New-PSRuleOption -Option (Join-Path -Path $here -ChildPath 'PSRule.Tests.yml');
             $option.Input.ObjectPath | Should -Be 'items';
         }
+
+        It 'from parameter' {
+            $option = New-PSRuleOption -InputObjectPath 'items' -Path $emptyOptionsFilePath;
+            $option.Input.ObjectPath | Should -Be 'items';
+        }
     }
 
     Context 'Read Logging.RuleFail' {
@@ -285,12 +327,17 @@ Describe 'New-PSRuleOption' -Tag 'Option','New-PSRuleOption' {
 
         It 'from Hashtable' {
             $option = New-PSRuleOption -Option @{ 'Logging.RuleFail' = 'Error' };
-            $option.Logging.RuleFail | Should -Be Error;
+            $option.Logging.RuleFail | Should -Be 'Error';
         }
 
         It 'from YAML' {
             $option = New-PSRuleOption -Option (Join-Path -Path $here -ChildPath 'PSRule.Tests.yml');
-            $option.Logging.RuleFail | Should -Be Warning;
+            $option.Logging.RuleFail | Should -Be 'Warning';
+        }
+
+        It 'from parameter' {
+            $option = New-PSRuleOption -LoggingRuleFail 'Warning' -Path $emptyOptionsFilePath;
+            $option.Logging.RuleFail | Should -Be 'Warning';
         }
     }
 
@@ -302,12 +349,17 @@ Describe 'New-PSRuleOption' -Tag 'Option','New-PSRuleOption' {
 
         It 'from Hashtable' {
             $option = New-PSRuleOption -Option @{ 'Logging.RulePass' = 'Error' };
-            $option.Logging.RulePass | Should -Be Error;
+            $option.Logging.RulePass | Should -Be 'Error';
         }
 
         It 'from YAML' {
             $option = New-PSRuleOption -Option (Join-Path -Path $here -ChildPath 'PSRule.Tests.yml');
-            $option.Logging.RulePass | Should -Be Warning;
+            $option.Logging.RulePass | Should -Be 'Warning';
+        }
+
+        It 'from parameter' {
+            $option = New-PSRuleOption -LoggingRulePass 'Warning' -Path $emptyOptionsFilePath;
+            $option.Logging.RulePass | Should -Be 'Warning';
         }
     }
 
@@ -319,12 +371,17 @@ Describe 'New-PSRuleOption' -Tag 'Option','New-PSRuleOption' {
 
         It 'from Hashtable' {
             $option = New-PSRuleOption -Option @{ 'Output.As' = 'Summary' };
-            $option.Output.As | Should -Be Summary;
+            $option.Output.As | Should -Be 'Summary';
         }
 
         It 'from YAML' {
             $option = New-PSRuleOption -Option (Join-Path -Path $here -ChildPath 'PSRule.Tests.yml');
-            $option.Output.As | Should -Be Summary;
+            $option.Output.As | Should -Be 'Summary';
+        }
+
+        It 'from parameter' {
+            $option = New-PSRuleOption -OutputAs 'Summary' -Path $emptyOptionsFilePath;
+            $option.Output.As | Should -Be 'Summary';
         }
     }
 
@@ -336,12 +393,17 @@ Describe 'New-PSRuleOption' -Tag 'Option','New-PSRuleOption' {
 
         It 'from Hashtable' {
             $option = New-PSRuleOption -Option @{ 'Output.Format' = 'Yaml' };
-            $option.Output.Format | Should -Be Yaml;
+            $option.Output.Format | Should -Be 'Yaml';
         }
 
         It 'from YAML' {
             $option = New-PSRuleOption -Option (Join-Path -Path $here -ChildPath 'PSRule.Tests.yml');
-            $option.Output.Format | Should -Be Json;
+            $option.Output.Format | Should -Be 'Json';
+        }
+
+        It 'from parameter' {
+            $option = New-PSRuleOption -OutputFormat 'Yaml' -Path $emptyOptionsFilePath;
+            $option.Output.Format | Should -Be 'Yaml';
         }
     }
 
@@ -365,3 +427,105 @@ Describe 'New-PSRuleOption' -Tag 'Option','New-PSRuleOption' {
 }
 
 #endregion New-PSRuleOption
+
+#region Set-PSRuleOption
+
+Describe 'Set-PSRuleOption' -Tag 'Option','Set-PSRuleOption' {
+    $emptyOptionsFilePath = (Join-Path -Path $here -ChildPath 'PSRule.Tests4.yml');
+    $optionParams = @{
+        Path = $emptyOptionsFilePath
+        PassThru = $True
+    }
+
+    # Baseline.RuleName
+    # Baseline.Exclude
+    # Baseline.Configuration
+
+    Context 'Read Binding.IgnoreCase' {
+        It 'from parameter' {
+            $option = Set-PSRuleOption -BindingIgnoreCase $False @optionParams;
+            $option.Binding.IgnoreCase | Should -Be $False;
+        }
+    }
+
+    Context 'Read Binding.TargetName' {
+        It 'from parameter' {
+            $option = Set-PSRuleOption -BindingTargetName 'ResourceName', 'AlternateName' @optionParams;
+            $option.Binding.TargetName | Should -BeIn 'ResourceName', 'AlternateName';
+        }
+    }
+
+    Context 'Read Binding.TargetType' {
+        It 'from parameter' {
+            $option = Set-PSRuleOption -BindingTargetType 'ResourceType', 'Kind' @optionParams;
+            $option.Binding.TargetType | Should -BeIn 'ResourceType', 'Kind';
+        }
+    }
+
+    Context 'Read Execution.LanguageMode' {
+        It 'from parameter' {
+            $option = Set-PSRuleOption -ExecutionLanguageMode 'ConstrainedLanguage' @optionParams;
+            $option.Execution.LanguageMode | Should -Be 'ConstrainedLanguage';
+        }
+    }
+
+    Context 'Read Execution.InconclusiveWarning' {
+        It 'from parameter' {
+            $option = Set-PSRuleOption -ExecutionInconclusiveWarning $False @optionParams;
+            $option.Execution.InconclusiveWarning | Should -Be $False;
+        }
+    }
+
+    Context 'Read Execution.NotProcessedWarning' {
+        It 'from parameter' {
+            $option = Set-PSRuleOption -ExecutionNotProcessedWarning $False @optionParams;
+            $option.Execution.NotProcessedWarning | Should -Be $False;
+        }
+    }
+
+    Context 'Read Input.Format' {
+        It 'from parameter' {
+            $option = Set-PSRuleOption -InputFormat 'Yaml' @optionParams;
+            $option.Input.Format | Should -Be 'Yaml';
+        }
+    }
+
+    Context 'Read Input.ObjectPath' {
+        It 'from parameter' {
+            $option = Set-PSRuleOption -InputObjectPath 'items' @optionParams;
+            $option.Input.ObjectPath | Should -Be 'items';
+        }
+    }
+
+    Context 'Read Logging.RuleFail' {
+        It 'from parameter' {
+            $option = Set-PSRuleOption -LoggingRuleFail 'Warning' @optionParams;
+            $option.Logging.RuleFail | Should -Be 'Warning';
+        }
+    }
+
+    Context 'Read Logging.RulePass' {
+        It 'from parameter' {
+            $option = Set-PSRuleOption -LoggingRulePass 'Warning' @optionParams;
+            $option.Logging.RulePass | Should -Be 'Warning';
+        }
+    }
+
+    Context 'Read Output.As' {
+        It 'from parameter' {
+            $option = Set-PSRuleOption -OutputAs 'Summary' @optionParams;
+            $option.Output.As | Should -Be 'Summary';
+        }
+    }
+
+    Context 'Read Output.Format' {
+        It 'from parameter' {
+            $option = Set-PSRuleOption -OutputFormat 'Yaml' @optionParams;
+            $option.Output.Format | Should -Be 'Yaml';
+        }
+    }
+    
+    # Suppression
+}
+
+#endregion Set-PSRuleOption

--- a/tests/PSRule.Tests/PSRule.Tests4.yml
+++ b/tests/PSRule.Tests/PSRule.Tests4.yml
@@ -1,0 +1,1 @@
+# Empty file for options testings


### PR DESCRIPTION
## PR Summary

- Added `Set-PSRuleOption` cmdlet to configure YAML options file. #135
- Added parameters to New-PSRuleOption to configure common options. #134

Fixes #135 
Fixes #134 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/BernieWhite/PSRule/blob/master/CHANGELOG.md) has been updated with change under unreleased section
