### PR TITLE
Fix for path space and exporting of recommend keyword #168 #171

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 
 ## Unreleased
 
+- Fix discovery of rules within paths that contain spaces fails. [#168](https://github.com/BernieWhite/PSRule/issues/168)
+
 ## v0.6.0-B190627 (pre-release)
 
 - **Important change**: Changed `Hint` keyword to `Recommend` to align with rule documentation. [#165](https://github.com/BernieWhite/PSRule/issues/165)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## Unreleased
 
 - Fix discovery of rules within paths that contain spaces fails. [#168](https://github.com/BernieWhite/PSRule/issues/168)
+- Fix exporting of `Recommend` keyword and `Hint` alias. [#171](https://github.com/BernieWhite/PSRule/issues/171)
 
 ## v0.6.0-B190627 (pre-release)
 

--- a/src/PSRule/Host/HostHelper.cs
+++ b/src/PSRule/Host/HostHelper.cs
@@ -115,7 +115,7 @@ namespace PSRule.Host
                     //PipelineContext.CurrentThread.UseSource(source: source);
 
                     // Invoke script
-                    ps.AddScript(source.Path, true);
+                    ps.AddScript(string.Concat("& '", source.Path, "'"), true);
                     var invokeResults = ps.Invoke();
 
                     if (ps.HadErrors)

--- a/src/PSRule/PSRule.psd1
+++ b/src/PSRule/PSRule.psd1
@@ -114,7 +114,6 @@ AliasesToExport = @(
 
 # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
 PrivateData = @{
-
     PSData = @{
 
         # Tags applied to this module. These help with module discovery in online galleries.

--- a/src/PSRule/PSRule.psd1
+++ b/src/PSRule/PSRule.psd1
@@ -85,7 +85,7 @@ FunctionsToExport = @(
     'Match'
     'TypeOf'
     'Within'
-    'Hint'
+    'Recommend'
 )
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
@@ -99,7 +99,9 @@ VariablesToExport = @(
 )
 
 # Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
-AliasesToExport = @()
+AliasesToExport = @(
+    'Hint'
+)
 
 # DSC resources to export from this module
 # DscResourcesToExport = @()

--- a/src/PSRule/PSRule.psm1
+++ b/src/PSRule/PSRule.psm1
@@ -1393,7 +1393,7 @@ function InitEditorServices {
                 'Recommend'
             );
 
-            New-Alias -Name 'Hint' -Value 'Recommend' -Force;
+            $Null = New-Alias -Name 'Hint' -Value 'Recommend' -Force -Scope Global;
 
             Export-ModuleMember -Alias @(
                 'Hint'

--- a/src/PSRule/PSRule.psm1
+++ b/src/PSRule/PSRule.psm1
@@ -528,7 +528,7 @@ function Get-PSRuleHelp {
 
                     if ($Online -and $result.Length -eq 1) {
                         $launchUri = $result.GetOnlineHelpUri();
-    
+
                         if ($Null -ne $launchUri) {
                             Write-Verbose -Message "[Get-PSRuleHelp] -- Launching online version: $($launchUri.OriginalString)";
                             LaunchOnlineHelp -Uri $launchUri -Verbose:$VerbosePreference;
@@ -604,7 +604,7 @@ function New-PSRuleOption {
         [Parameter(Mandatory = $False)]
         [Alias('ExecutionInconclusiveWarning')]
         [System.Boolean]$InconclusiveWarning = $True,
-    
+
         # Sets the Execution.NotProcessedWarning option
         [Parameter(Mandatory = $False)]
         [Alias('ExecutionNotProcessedWarning')]
@@ -758,7 +758,7 @@ function Set-PSRuleOption {
         [Parameter(Mandatory = $False)]
         [Alias('ExecutionInconclusiveWarning')]
         [System.Boolean]$InconclusiveWarning = $True,
-    
+
         # Sets the Execution.NotProcessedWarning option
         [Parameter(Mandatory = $False)]
         [Alias('ExecutionNotProcessedWarning')]
@@ -1218,7 +1218,7 @@ function SetOptions {
         [Parameter(Mandatory = $False)]
         [Alias('ExecutionInconclusiveWarning')]
         [System.Boolean]$InconclusiveWarning = $True,
-    
+
         # Sets the Execution.NotProcessedWarning option
         [Parameter(Mandatory = $False)]
         [Alias('ExecutionNotProcessedWarning')]
@@ -1377,6 +1377,7 @@ function LaunchOnlineHelp {
 }
 
 function InitEditorServices {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidGlobalAliases', '', Justification = 'Alias is used for editor discovery only.', Scope = 'Function')]
     [CmdletBinding()]
     param ()
 
@@ -1393,8 +1394,8 @@ function InitEditorServices {
                 'Recommend'
             );
 
-            $Null = New-Alias -Name 'Hint' -Value 'Recommend' -Force -Scope Global;
-
+            # Define aliases
+            $Null = New-Alias -Name Hint -Value Recommend -Scope Global -Force;
             Export-ModuleMember -Alias @(
                 'Hint'
             );

--- a/tests/PSRule.Tests/PSRule.PSGallery.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.PSGallery.Tests.ps1
@@ -15,15 +15,20 @@ Set-StrictMode -Version latest;
 $rootPath = $PWD;
 
 Describe 'PSRule' -Tag 'PowerShellGallery' {
+    $modulePath = (Join-Path -Path $rootPath -ChildPath out/modules/PSRule);
+
     Context 'Module' {
         It 'Can be imported' {
-            Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule) -Force;
+            Import-Module $modulePath -Force;
         }
     }
 
     Context 'Manifest' {
         $manifestPath = (Join-Path -Path $rootPath -ChildPath out/modules/PSRule/PSRule.psd1);
         $result = Test-ModuleManifest -Path $manifestPath;
+        $Global:psEditor = $True;
+        $Null = Import-Module $modulePath -Force;
+        $commands = Get-Command -Module PSRule -All;
 
         It 'Has required fields' {
             $result.Name | Should -Be 'PSRule';
@@ -33,12 +38,34 @@ Describe 'PSRule' -Tag 'PowerShellGallery' {
         }
 
         It 'Exports functions' {
-            'Invoke-PSRule', 'Get-PSRule', 'New-PSRuleOption', 'Rule' | Should -BeIn $result.ExportedFunctions.Keys;
+            $filteredCommands = @($commands | Where-Object -FilterScript { $_ -is [System.Management.Automation.FunctionInfo] });
+            $filteredCommands | Should -Not -BeNullOrEmpty;
+            $expected = @(
+                'Invoke-PSRule'
+                'Get-PSRule'
+                'Get-PSRuleHelp'
+                'Test-PSRuleTarget'
+                'New-PSRuleOption'
+                'Set-PSRuleOption'
+                'Rule'
+            )
+            $expected | Should -BeIn $filteredCommands.Name;
+            $expected | Should -BeIn $result.ExportedFunctions.Keys;
+        }
+
+        It 'Exports aliases' {
+            $filteredCommands = @($commands | Where-Object -FilterScript { $_ -is [System.Management.Automation.AliasInfo] });
+            $filteredCommands | Should -Not -BeNullOrEmpty;
+            $expected = @(
+                'Hint'
+            )
+            $expected | Should -BeIn $filteredCommands.Name;
+            $expected | Should -BeIn $result.ExportedAliases.Keys;
         }
     }
 
     Context 'Static analysis' {
-        $result = Invoke-ScriptAnalyzer -Path (Join-Path -Path $rootPath -ChildPath out/modules/PSRule);
+        $result = Invoke-ScriptAnalyzer -Path $modulePath;
 
         $warningCount = ($result | Where-Object { $_.Severity -eq 'Warning' } | Measure-Object).Count;
         $errorCount = ($result | Where-Object { $_.Severity -eq 'Error' } | Measure-Object).Count;


### PR DESCRIPTION
## PR Summary

- Fix discovery of rules within paths that contain spaces fails. #168
- Fix exporting of `Recommend` keyword and `Hint` alias. #171

Fixes #168 
Fixes #171 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/BernieWhite/PSRule/blob/master/CHANGELOG.md) has been updated with change under unreleased section
