### PR TITLE
Fix circular dependencies and rule nesting error handling #190 #189

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 
 ## Unreleased
 
+- Fix circular rule dependency issue. [#190](https://github.com/BernieWhite/PSRule/issues/190)
+- Fix error message when attempting to use the rule keyword in a rule definition. [#189](https://github.com/BernieWhite/PSRule/issues/189)
+
 ## v0.7.0-B190624 (pre-release)
 
 - Fix handling of non-boolean results in rules. Rule is failed with more specific error message. [#187](https://github.com/BernieWhite/PSRule/issues/187)

--- a/src/PSRule/Commands/NewRuleDefinitionCommand.cs
+++ b/src/PSRule/Commands/NewRuleDefinitionCommand.cs
@@ -70,6 +70,17 @@ namespace PSRule.Commands
 
             context.VerboseFoundRule(ruleName: Name, scriptName: MyInvocation.ScriptName);
 
+            var visitor = new RuleLanguageAst(ruleName: Name, context: context);
+            Body.Ast.Visit(visitor);
+
+            if (visitor.Errors != null)
+            {
+                foreach (var errorRecord in visitor.Errors)
+                {
+                    WriteError(errorRecord: errorRecord);
+                }
+            }
+
             var ps = PowerShell.Create();
             ps.Runspace = context.GetRunspace();
             ps.AddCommand(new CmdletInfo(InvokeBlockCmdletName, typeof(InvokeRuleBlockCommand)));

--- a/src/PSRule/Commands/RuleLanguageAst.cs
+++ b/src/PSRule/Commands/RuleLanguageAst.cs
@@ -1,0 +1,50 @@
+﻿using PSRule.Pipeline;
+using PSRule.Resources;
+using System;
+using System.Collections.Generic;
+using System.Management.Automation;
+using System.Management.Automation.Language;
+
+namespace PSRule.Commands
+{
+    internal sealed class RuleLanguageAst : AstVisitor
+    {
+        private readonly string _RuleName;
+        private readonly StringComparer _Comparer;
+
+        internal List<ErrorRecord> Errors;
+
+        internal RuleLanguageAst(string ruleName, PipelineContext context)
+        {
+            _RuleName = ruleName;
+            _Comparer = StringComparer.OrdinalIgnoreCase;
+        }
+
+        public override AstVisitAction VisitCommand(CommandAst commandAst)
+        {
+            string commandName = commandAst.GetCommandName();
+
+            if (_Comparer.Compare(commandName, "Rule") == 0)
+            {
+                ReportError(message: string.Format(PSRuleResources.InvalidRuleNesting, _RuleName), errorId: "PSRule.Runtime.InvalidRuleNesting");
+            }
+
+            return base.VisitCommand(commandAst);
+        }
+
+        private void ReportError(string message, string errorId)
+        {
+            if (Errors == null)
+            {
+                Errors = new List<ErrorRecord>();
+            }
+
+            Errors.Add(new ErrorRecord(
+                exception: new RuleRuntimeException(message: message),
+                errorId: errorId,
+                errorCategory: ErrorCategory.InvalidOperation,
+                targetObject: null
+            ));
+        }
+    }
+}

--- a/src/PSRule/PSRule.psm1
+++ b/src/PSRule/PSRule.psm1
@@ -160,8 +160,13 @@ function Invoke-PSRule {
 
         $builder.UseCommandRuntime($PSCmdlet.CommandRuntime);
         $builder.UseLoggingPreferences($ErrorActionPreference, $WarningPreference, $VerbosePreference, $InformationPreference);
-        $pipeline = $builder.Build();
-        $pipeline.Begin();
+        try {
+            $pipeline = $builder.Build();
+            $pipeline.Begin();
+        }
+        catch {
+            throw $_.Exception.GetBaseException();
+        }
     }
 
     process {
@@ -299,8 +304,13 @@ function Test-PSRuleTarget {
         $builder.UseCommandRuntime($PSCmdlet.CommandRuntime);
         $builder.UseLoggingPreferences($ErrorActionPreference, $WarningPreference, $VerbosePreference, $InformationPreference);
         $builder.ReturnBoolean();
-        $pipeline = $builder.Build();
-        $pipeline.Begin();
+        try {
+            $pipeline = $builder.Build();
+            $pipeline.Begin();
+        }
+        catch {
+            throw $_.Exception.GetBaseException();
+        }
     }
 
     process {
@@ -419,7 +429,12 @@ function Get-PSRule {
         $builder.Source($sourceFiles);
         $builder.UseCommandRuntime($PSCmdlet.CommandRuntime);
         $builder.UseLoggingPreferences($ErrorActionPreference, $WarningPreference, $VerbosePreference, $InformationPreference);
-        $pipeline = $builder.Build();
+        try {
+            $pipeline = $builder.Build();
+        }
+        catch {
+            throw $_.Exception.GetBaseException();
+        }
     }
 
     process {

--- a/src/PSRule/Resources/PSRuleResources.Designer.cs
+++ b/src/PSRule/Resources/PSRuleResources.Designer.cs
@@ -61,6 +61,42 @@ namespace PSRule.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to A circular rule dependency was detected. The rule &apos;{0}&apos; depends on &apos;{1}&apos; which also depend on &apos;{0}&apos;..
+        /// </summary>
+        internal static string DependencyCircularReference {
+            get {
+                return ResourceManager.GetString("DependencyCircularReference", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The dependency &apos;{0}&apos; for &apos;{1}&apos; could not be found. Check that the rule is defined in a .Rule.ps1 file within the search path..
+        /// </summary>
+        internal static string DependencyNotFound {
+            get {
+                return ResourceManager.GetString("DependencyNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A rule with the same name &apos;{0}&apos; already exists..
+        /// </summary>
+        internal static string DuplicateRuleId {
+            get {
+                return ResourceManager.GetString("DuplicateRuleId", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rule nesting was detected in rule &apos;{0}&apos;. Rules must not be nested..
+        /// </summary>
+        internal static string InvalidRuleNesting {
+            get {
+                return ResourceManager.GetString("InvalidRuleNesting", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to An invalid rule result was returned for {0}. Conditions must return boolean $True or $False..
         /// </summary>
         internal static string InvalidRuleResult {

--- a/src/PSRule/Resources/PSRuleResources.resx
+++ b/src/PSRule/Resources/PSRuleResources.resx
@@ -117,6 +117,22 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="DependencyCircularReference" xml:space="preserve">
+    <value>A circular rule dependency was detected. The rule '{0}' depends on '{1}' which also depend on '{0}'.</value>
+    <comment>Occurs when rules interdepend on each other.</comment>
+  </data>
+  <data name="DependencyNotFound" xml:space="preserve">
+    <value>The dependency '{0}' for '{1}' could not be found. Check that the rule is defined in a .Rule.ps1 file within the search path.</value>
+    <comment>Occurs when a rule dependency is not discovered.</comment>
+  </data>
+  <data name="DuplicateRuleId" xml:space="preserve">
+    <value>A rule with the same name '{0}' already exists.</value>
+    <comment>Occurs when the same rule name is used.</comment>
+  </data>
+  <data name="InvalidRuleNesting" xml:space="preserve">
+    <value>Rule nesting was detected in rule '{0}'. Rules must not be nested.</value>
+    <comment>Occurs when a rule is nested in another rule.</comment>
+  </data>
   <data name="InvalidRuleResult" xml:space="preserve">
     <value>An invalid rule result was returned for {0}. Conditions must return boolean $True or $False.</value>
   </data>

--- a/tests/PSRule.Tests/FromFileNested.Rule.ps1
+++ b/tests/PSRule.Tests/FromFileNested.Rule.ps1
@@ -1,0 +1,10 @@
+#
+# Pester unit test rules checking nesting
+#
+
+# Synopsis: Should error with nested rule
+Rule 'WithNestedRule' {
+    Rule 'NestedRule' {
+        $True;
+    }
+}

--- a/tests/PSRule.Tests/FromFileWithError.Rule.ps1
+++ b/tests/PSRule.Tests/FromFileWithError.Rule.ps1
@@ -7,3 +7,15 @@ Rule 'WithNonBoolean' {
     $True
     'false' # Not a boolean
 }
+
+Rule 'WithDependency1' -DependsOn 'WithDependency2' {
+    $True;
+}
+
+Rule 'WithDependency2' -DependsOn 'WithDependency3' {
+    $True;
+}
+
+Rule 'WithDependency3' -DependsOn 'WithDependency1' {
+    $True;
+}


### PR DESCRIPTION
## PR Summary

- Fix circular rule dependency issue. #190
- Fix error message when attempting to use the rule keyword in a rule definition. #189

Fixes #190 
Fixes #189 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/BernieWhite/PSRule/blob/master/CHANGELOG.md) has been updated with change under unreleased section
