### PR TITLE
TypeOf TypeName parameter is case sensitive #201

### DIFF
--- a/docs/keywords/PSRule/en-US/about_PSRule_Keywords.md
+++ b/docs/keywords/PSRule/en-US/about_PSRule_Keywords.md
@@ -254,7 +254,7 @@ Syntax:
 TypeOf [-TypeName] <string[]> [-InputObject <PSObject>]
 ```
 
-- `TypeName` - One or more type names which will be evaluated against the pipeline object. `TypeName` is case insensitive.
+- `TypeName` - One or more type names which will be evaluated against the pipeline object. `TypeName` is case sensitive.
 - `InputObject` - Supports objects being piped directly.
 
 Examples:


### PR DESCRIPTION
## PR Summary

- Fix documentation error, `TypeOf -TypeName` is case sensitive. #201

Fixes #201

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
