### PR TITLE
Fix marking GitHub releases as pre-release

### DIFF
--- a/.azure-pipelines/azure-pipelines.yaml
+++ b/.azure-pipelines/azure-pipelines.yaml
@@ -162,4 +162,4 @@ stages:
         releaseNotes: 'See [change log](https://github.com/BernieWhite/PSRule/blob/master/CHANGELOG.md)'
         assetUploadMode: replace
         addChangeLog: false
-        isPreRelease: $[ contains(variables['Build.SourceBranchName'], '-B') ]
+        isPreRelease: contains(variables['Build.SourceBranchName'], '-B')


### PR DESCRIPTION
## PR Summary

- Fix marking GitHub releases as pre-release in CI pipeline.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
