### PR TITLE
Add -Not to Within and Match keywords #208

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 
 ## Unreleased
 
+- Add `-Not` switch to `Within` and `Match` keywords to allow negative comparison. [#208](https://github.com/BernieWhite/PSRule/issues/208)
+
 ## v0.7.0-B190633 (pre-release)
 
 - Fix circular rule dependency issue. [#190](https://github.com/BernieWhite/PSRule/issues/190)

--- a/docs/keywords/PSRule/en-US/about_PSRule_Keywords.md
+++ b/docs/keywords/PSRule/en-US/about_PSRule_Keywords.md
@@ -131,12 +131,13 @@ The `Match` assertion is used within a `Rule` definition to assert that the valu
 Syntax:
 
 ```text
-Match [-Field] <string> [-Expression] <string[]> [-CaseSensitive] [-InputObject <PSObject>]
+Match [-Field] <string> [-Expression] <string[]> [-CaseSensitive] [-Not] [-InputObject <PSObject>]
 ```
 
 - `Field` - The name of the field that will be evaluated on the pipeline object.
 - `Expression` - One or more regular expressions that will be used to match the value of the field.
 - `CaseSensitive` - The field _value_ must match exact case.
+- `Not` - Instead of checking the field value matches, the field value must not match any of the expressions.
 - `InputObject` - Supports objects being piped directly.
 
 Examples:
@@ -150,7 +151,9 @@ Rule 'validatePhoneNumber' {
 
 Output:
 
-If **any** of the specified regular expressions match the field value then Match returns `$True`, otherwise `$False`.
+If **any** of the specified regular expressions match the field value then `Match` returns `$True`, otherwise `$False`.
+
+When `-Not` is used, if any of the regular expressions match the field value with `Match` return `$False`, otherwise `$True`.
 
 ### Within
 
@@ -159,12 +162,13 @@ The `Within` assertion is used within a `Rule` definition to assert that the val
 Syntax:
 
 ```text
-Within [-Field] <string> [-AllowedValue] <PSObject[]]> [-CaseSensitive] [-InputObject <PSObject>]
+Within [-Field] <string> [[-Value] <PSObject[]>] [-CaseSensitive] [-Not] [-InputObject <PSObject>]
 ```
 
 - `Field` - The name of the field that will be evaluated on the pipeline object.
-- `AllowedValue` - A list of allowed values that the field value must match.
+- `Value` - A list of values that the field value must match.
 - `CaseSensitive` - The field _value_ must match exact case. Only applies when the field value and allowed values are strings.
+- `Not` - Instead of checking the field value matches, the field value must not match any of the supplied values.
 - `InputObject` - Supports objects being piped directly.
 
 Examples:
@@ -176,9 +180,18 @@ Rule 'validateTitle' {
 }
 ```
 
+```powershell
+# Synopsis: Ensure that the title field is not one of the specified values
+Rule 'validateTitle' {
+    Within 'Title' 'Mr', 'Sir' -Not
+}
+```
+
 Output:
 
-If **any** of the allow values match the field value then Within returns `$True`, otherwise `$False`.
+If **any** of the values match the field value then `Within` returns `$True`, otherwise `$False`.
+
+When `-Not` is used, if any of the values match the field value with `Within` return `$False`, otherwise `$True`.
 
 ### AllOf
 

--- a/src/PSRule/PSRule.psm1
+++ b/src/PSRule/PSRule.psm1
@@ -1046,6 +1046,9 @@ function Match {
         [Parameter(Mandatory = $False)]
         [Switch]$CaseSensitive = $False,
 
+        [Parameter(Mandatory = $False)]
+        [Switch]$Not = $False,
+
         [Parameter(Mandatory = $False, ValueFromPipeline = $True)]
         [PSObject]$InputObject
     )
@@ -1068,10 +1071,14 @@ function Within {
         [String]$Field,
 
         [Parameter(Mandatory = $True, Position = 1)]
-        [PSObject[]]$AllowedValue,
+        [Alias('AllowedValue')]
+        [PSObject[]]$Value,
 
         [Parameter(Mandatory = $False)]
         [Switch]$CaseSensitive = $False,
+
+        [Parameter(Mandatory = $False)]
+        [Switch]$Not = $False,
 
         [Parameter(Mandatory = $False, ValueFromPipeline = $True)]
         [PSObject]$InputObject

--- a/tests/PSRule.Tests/FromFile.Rule.ps1
+++ b/tests/PSRule.Tests/FromFile.Rule.ps1
@@ -203,6 +203,11 @@ Rule 'WithinTestCaseSensitive' {
     Within 'Title' 'Mr', 'Miss', 'Mrs', 'Ms' -CaseSensitive
 }
 
+# Synopsis: Test for Within keyword
+Rule 'WithinNot' {
+    Within 'Title' 'Mr', 'Sir' -Not
+}
+
 # Synopsis: Test for Match keyword
 Rule 'MatchTest' -Tag @{ keyword = 'Match' } {
     AnyOf {
@@ -217,6 +222,11 @@ Rule 'MatchTest' -Tag @{ keyword = 'Match' } {
 # Synopsis: Test for Match keyword
 Rule 'MatchTestCaseSensitive' -Tag @{ keyword = 'Match' } {
     Match 'Title' '^(Mr|Miss|Mrs|Ms)$' -CaseSensitive
+}
+
+# Synopsis: Test for Match keyword
+Rule 'MatchNot' {
+    Match 'Title' '^(Mr|Sir)$' -Not
 }
 
 # Synopsis: Test for TypeOf keyword

--- a/tests/PSRule.Tests/PSRule.Match.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Match.Tests.ps1
@@ -18,8 +18,10 @@ Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule) -Force;
 $here = (Resolve-Path $PSScriptRoot).Path;
 
 Describe 'PSRule -- Match keyword' -Tag 'Match' {
+    $ruleFilePath = (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1');
+
     Context 'Match' {
-        It 'Evaluates regex' {
+        It 'With defaults' {
             # Test positive cases
             $goodObjects = @(
                 [PSCustomObject]@{ PhoneNumber = '0400 000 000' }
@@ -27,7 +29,7 @@ Describe 'PSRule -- Match keyword' -Tag 'Match' {
                 @{ PhoneNumber = '000' }
                 @{ Value = @{ PhoneNumber = '0400 000 000' }}
             )
-            $result = $goodObjects | Invoke-PSRule -Path (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1') -Name 'MatchTest';
+            $result = $goodObjects | Invoke-PSRule -Path $ruleFilePath -Name 'MatchTest';
             $result | Should -Not -BeNullOrEmpty;
             $result.Count | Should -Be 4;
             $result.Outcome | Should -BeIn 'Pass';
@@ -40,21 +42,21 @@ Describe 'PSRule -- Match keyword' -Tag 'Match' {
                 [PSCustomObject]@{ PhoneNumber = '100' }
                 @{ PhoneNumber = '100' }
             )
-            $result = $badObjects | Invoke-PSRule -Path (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1') -Name 'MatchTest';
+            $result = $badObjects | Invoke-PSRule -Path $ruleFilePath -Name 'MatchTest';
             $result | Should -Not -BeNullOrEmpty;
             $result.Count | Should -Be 4;
             $result.Outcome | Should -BeIn 'Fail';
             $result.RuleName | Should -BeIn 'MatchTest';
         }
 
-        It 'Evaluates regex with case sensitivity' {
+        It 'With -CaseSensitive' {
             # Test positive cases
             $goodObjects = @(
                 [PSCustomObject]@{ Title = 'Mr' }
                 [PSCustomObject]@{ tiTle = 'Miss' }
                 @{ Title = 'Miss' }
             )
-            $result = $goodObjects | Invoke-PSRule -Path (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1') -Name 'MatchTestCaseSensitive';
+            $result = $goodObjects | Invoke-PSRule -Path $ruleFilePath -Name 'MatchTestCaseSensitive';
             $result | Should -Not -BeNullOrEmpty;
             $result.Count | Should -Be 3;
             $result.Outcome | Should -BeIn 'Pass';
@@ -66,11 +68,25 @@ Describe 'PSRule -- Match keyword' -Tag 'Match' {
                 [PSCustomObject]@{ tiTle = 'miss' }
                 @{ Title = 'miss' }
             )
-            $result = $badObjects | Invoke-PSRule -Path (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1') -Name 'MatchTestCaseSensitive';
+            $result = $badObjects | Invoke-PSRule -Path $ruleFilePath -Name 'MatchTestCaseSensitive';
             $result | Should -Not -BeNullOrEmpty;
             $result.Count | Should -Be 3;
             $result.Outcome | Should -BeIn 'Fail';
             $result.RuleName | Should -BeIn 'MatchTestCaseSensitive';
+        }
+
+        It 'With -Not' {
+            $testObject = @(
+                [PSCustomObject]@{ Title = 'Miss' }
+                [PSCustomObject]@{ Title = 'Mr' }
+            )
+
+            $result = $testObject | Invoke-PSRule -Path $ruleFilePath -Name 'MatchNot';
+            $result | Should -Not -BeNullOrEmpty;
+            $result.Count | Should -Be 2;
+            $result.RuleName | Should -BeIn 'MatchNot';
+            $result[0].IsSuccess() | Should -Be $True;
+            $result[1].IsSuccess() | Should -Be $False;
         }
     }
 }

--- a/tests/PSRule.Tests/PSRule.Within.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Within.Tests.ps1
@@ -18,8 +18,10 @@ Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule) -Force;
 $here = (Resolve-Path $PSScriptRoot).Path;
 
 Describe 'PSRule -- Within keyword' -Tag 'Within' {
+    $ruleFilePath = (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1');
+
     Context 'Within' {
-        It 'Matches list' {
+        It 'With defaults' {
             $testObject = @(
                 [PSCustomObject]@{ Title = 'mr' }
                 [PSCustomObject]@{ Title = 'unknown' }
@@ -28,10 +30,10 @@ Describe 'PSRule -- Within keyword' -Tag 'Within' {
                 @{ NotTitle = 'a different property' }
             )
 
-            $result = $testObject | Invoke-PSRule -Path (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1') -Name 'WithinTest' -Outcome All;
+            $result = $testObject | Invoke-PSRule -Path $ruleFilePath -Name 'WithinTest' -Outcome All;
             $result | Should -Not -BeNullOrEmpty;
             $result.Count | Should -Be 5;
-            $result.RuleName | Should -BeIn 'WithinTest'
+            $result.RuleName | Should -BeIn 'WithinTest';
             $result[0].IsSuccess() | Should -Be $True;
             $result[1].IsSuccess() | Should -Be $False;
             $result[2].IsSuccess() | Should -Be $True;
@@ -39,20 +41,34 @@ Describe 'PSRule -- Within keyword' -Tag 'Within' {
             $result[4].IsSuccess() | Should -Be $False;
         }
 
-        It 'Matches list with case sensitivity' {
+        It 'With -CaseSensitive' {
             $testObject = @(
                 [PSCustomObject]@{ Title = 'mr' }
                 [PSCustomObject]@{ Title = 'Mr' }
                 @{ Title = 'Mr' }
             )
 
-            $result = $testObject | Invoke-PSRule -Path (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1') -Name 'WithinTestCaseSensitive';
+            $result = $testObject | Invoke-PSRule -Path $ruleFilePath -Name 'WithinTestCaseSensitive';
             $result | Should -Not -BeNullOrEmpty;
             $result.Count | Should -Be 3;
-            $result.RuleName | Should -BeIn 'WithinTestCaseSensitive'
+            $result.RuleName | Should -BeIn 'WithinTestCaseSensitive';
             $result[0].IsSuccess() | Should -Be $False;
             $result[1].IsSuccess() | Should -Be $True;
             $result[2].IsSuccess() | Should -Be $True;
+        }
+
+        It 'With -Not' {
+            $testObject = @(
+                [PSCustomObject]@{ Title = 'Miss' }
+                [PSCustomObject]@{ Title = 'Mr' }
+            )
+
+            $result = $testObject | Invoke-PSRule -Path $ruleFilePath -Name 'WithinNot';
+            $result | Should -Not -BeNullOrEmpty;
+            $result.Count | Should -Be 2;
+            $result.RuleName | Should -BeIn 'WithinNot';
+            $result[0].IsSuccess() | Should -Be $True;
+            $result[1].IsSuccess() | Should -Be $False;
         }
     }
 }


### PR DESCRIPTION
## PR Summary

- Add `-Not` switch to `Within` and `Match` keywords to allow negative comparison. #208

#208 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/BernieWhite/PSRule/blob/master/CHANGELOG.md) has been updated with change under unreleased section
