### PR TITLE
Fix TargetName binding of null #202

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## Unreleased
 
 - Add `-Not` switch to `Within` and `Match` keywords to allow negative comparison. [#208](https://github.com/BernieWhite/PSRule/issues/208)
+- Fix TargetName binding when TargetName or Name property is null. [#202](https://github.com/BernieWhite/PSRule/issues/202)
 
 ## v0.7.0-B190633 (pre-release)
 

--- a/src/PSRule/Pipeline/PipelineHookActions.cs
+++ b/src/PSRule/Pipeline/PipelineHookActions.cs
@@ -22,21 +22,13 @@ namespace PSRule.Pipeline
         /// <returns>The TargetName of the object.</returns>
         public static string DefaultTargetNameBinding(PSObject targetObject)
         {
-            string targetName = null;
-
-            targetName = targetObject.Properties[Property_TargetName]?.Value.ToString();
-
-            if (targetName == null)
+            if (TryGetTargetName(targetObject: targetObject, propertyName: Property_TargetName, out string targetName) ||
+                TryGetTargetName(targetObject: targetObject, propertyName: Property_Name, out targetName))
             {
-                targetName = targetObject.Properties[Property_Name]?.Value.ToString();
+                return targetName;
             }
 
-            if (targetName == null)
-            {
-                return GetUnboundObjectTargetName(targetObject);
-            }
-
-            return targetName;
+            return GetUnboundObjectTargetName(targetObject);
         }
 
         /// <summary>
@@ -96,6 +88,15 @@ namespace PSRule.Pipeline
             var json = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(targetObject, settings));
             var hash = PipelineContext.CurrentThread.ObjectHashAlgorithm.ComputeHash(json);
             return string.Join("", hash.Select(b => b.ToString("x2")).ToArray());
+        }
+
+        /// <summary>
+        /// Try to get TargetName from specified property.
+        /// </summary>
+        private static bool TryGetTargetName(PSObject targetObject, string propertyName, out string targetName)
+        {
+            targetName = targetObject.Properties[propertyName]?.Value?.ToString();
+            return targetName != null;
         }
 
         /// <summary>

--- a/src/PSRule/Pipeline/PipelineHookActions.cs
+++ b/src/PSRule/Pipeline/PipelineHookActions.cs
@@ -22,8 +22,8 @@ namespace PSRule.Pipeline
         /// <returns>The TargetName of the object.</returns>
         public static string DefaultTargetNameBinding(PSObject targetObject)
         {
-            if (TryGetTargetName(targetObject: targetObject, propertyName: Property_TargetName, out string targetName) ||
-                TryGetTargetName(targetObject: targetObject, propertyName: Property_Name, out targetName))
+            if (TryGetTargetName(targetObject: targetObject, propertyName: Property_TargetName, targetName: out string targetName) ||
+                TryGetTargetName(targetObject: targetObject, propertyName: Property_Name, targetName: out targetName))
             {
                 return targetName;
             }

--- a/tests/PSRule.Tests/PSRule.Common.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Common.Tests.ps1
@@ -527,8 +527,8 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
     Context 'TargetName binding' {
         It 'Binds to TargetName' {
             $testObject = [PSCustomObject]@{
-                TargetName = "ObjectTargetName"
-                Name = "ObjectName"
+                TargetName = 'ObjectTargetName'
+                Name = 'ObjectName'
                 Value = 1
             }
 
@@ -539,25 +539,32 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
         }
 
         It 'Binds to Name' {
-            $testObject = [PSCustomObject]@{
-                Name = 'TestObject1'
-            }
+            $testObject = @(
+                [PSCustomObject]@{ Name = 'TestObject1' }
+                (1 | Select-Object -Property Name)
+            )
 
-            $result = $testObject | Invoke-PSRule -Path $ruleFilePath -Name 'FromFile1';
+            $result = @($testObject | Invoke-PSRule -Path $ruleFilePath -Name 'FromFile1');
             $result | Should -Not -BeNullOrEmpty;
-            $result.IsSuccess() | Should -Be $True;
-            $result.TargetName | Should -Be 'TestObject1';
+            $result.Length | Should -Be 2;
+            $result[0].IsSuccess() | Should -Be $True;
+            $result[1].IsSuccess() | Should -Be $True;
+            $result[0].TargetName | Should -Be 'TestObject1';
         }
 
         It 'Binds to object hash' {
-            $testObject = [PSCustomObject]@{
-                NotName = 'TestObject1'
-            }
+            $testObject = @(
+                [PSCustomObject]@{ NotName = 'TestObject1' }
+                (1 | Select-Object -Property Name)
+            )
 
-            $result = $testObject | Invoke-PSRule -Path $ruleFilePath -Name 'FromFile1';
+            $result = @($testObject | Invoke-PSRule -Path $ruleFilePath -Name 'FromFile1');
             $result | Should -Not -BeNullOrEmpty;
-            $result.IsSuccess() | Should -BeIn $True;
-            $result.TargetName | Should -BeIn 'f209c623345144be61087d91f30c17b01c6e86d2';
+            $result.Length | Should -Be 2;
+            $result[0].IsSuccess() | Should -Be $True;
+            $result[1].IsSuccess() | Should -Be $True;
+            $result[0].TargetName | Should -BeIn 'f209c623345144be61087d91f30c17b01c6e86d2';
+            $result[1].TargetName | Should -BeIn '3b8eeb35831ea8f7b5de4e0cf04f32b9a1233a0d';
         }
 
         It 'Binds to custom name' {
@@ -655,7 +662,6 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
         }
 
         It 'Binds to custom type by script' {
-
             $bindFn = {
                 param ($TargetObject)
 

--- a/tests/PSRule.Tests/PSRule.TypeOf.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.TypeOf.Tests.ps1
@@ -18,6 +18,8 @@ Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule) -Force;
 $here = (Resolve-Path $PSScriptRoot).Path;
 
 Describe 'PSRule -- TypeOf keyword' -Tag 'TypeOf' {
+    $ruleFilePath = (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1');
+
     Context 'TypeOf' {
         It 'Matches type names' {
             $hashTableObject = @{ Key = 'Value' }
@@ -26,7 +28,7 @@ Describe 'PSRule -- TypeOf keyword' -Tag 'TypeOf' {
             $customObjectWithName = [PSCustomObject]@{ Key = 'Value' }; $customObjectWithName.PSObject.TypeNames.Add('PSRule.Test.OtherType');
             $testObject = @($hashTableObject, $hashTableObjectWithName1, $hashTableObjectWithName2, $customObjectWithName);
 
-            $result = $testObject | Invoke-PSRule -Path (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1') -Name 'TypeOfTest';
+            $result = $testObject | Invoke-PSRule -Path $ruleFilePath -Name 'TypeOfTest';
             $result | Should -Not -BeNullOrEmpty;
             $result.Count | Should -Be 4;
             $result.IsSuccess() | Should -BeIn $True;
@@ -38,7 +40,7 @@ Describe 'PSRule -- TypeOf keyword' -Tag 'TypeOf' {
                 Key = 'Value'
             }
 
-            $result = $testObject | Invoke-PSRule -Path (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1') -Name 'TypeOfTest';
+            $result = $testObject | Invoke-PSRule -Path $ruleFilePath -Name 'TypeOfTest';
             $result | Should -Not -BeNullOrEmpty;
             $result.IsSuccess() | Should -Be $False;
             $result.RuleName | Should -Be 'TypeOfTest';


### PR DESCRIPTION
## PR Summary

- Fix TargetName binding when TargetName or Name property is null. #202

Fixes #202 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/BernieWhite/PSRule/blob/master/CHANGELOG.md) has been updated with change under unreleased section
