### PR TITLE
Add culture support for rule informational messages #158

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 
 ## Unreleased
 
-- Add `-Not` switch to `Within` and `Match` keywords to allow negative comparison. [#208](https://github.com/BernieWhite/PSRule/issues/208)
 - Fix TargetName binding when TargetName or Name property is null. [#202](https://github.com/BernieWhite/PSRule/issues/202)
+- Add culture support for PowerShell informational messages. [#158](https://github.com/BernieWhite/PSRule/issues/158)
+  - A new `$LocalizedData` variable can be used within rule definitions.
+- Add `-Not` switch to `Within` and `Match` keywords to allow negative comparison. [#208](https://github.com/BernieWhite/PSRule/issues/208)
 
 ## v0.7.0-B190633 (pre-release)
 

--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ The following conceptual topics exist in the `PSRule` module:
   - [Suppression](docs/concepts/PSRule/en-US/about_PSRule_Options.md#rule-suppression)
 - [Variables](docs/concepts/PSRule/en-US/about_PSRule_Variables.md)
   - [$Configuration](docs/concepts/PSRule/en-US/about_PSRule_Variables.md#configuration)
+  - [$LocalizedData](docs/concepts/PSRule/en-US/about_PSRule_Variables.md#localizeddata)
   - [$Rule](docs/concepts/PSRule/en-US/about_PSRule_Variables.md#rule)
   - [$TargetObject](docs/concepts/PSRule/en-US/about_PSRule_Variables.md#targetobject)
 

--- a/docs/concepts/PSRule/en-US/about_PSRule_Variables.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Variables.md
@@ -17,16 +17,17 @@ These variables are only available while `Invoke-PSRule` is executing.
 The following variables are available for use:
 
 - [$Configuration](#configuration)
+- [$LocalizedData](#localizeddata)
 - [$Rule](#rule)
 - [$TargetObject](#targetobject)
 
 ### Configuration
 
-A configuration object with properties names for each configuration value set in the baseline.
+A hashtable object with properties names for each configuration value set in the baseline.
 
 When accessing configuration:
 
-- Configuration values are read only.
+- Property values are read only.
 - Property names are case sensitive.
 
 Syntax:
@@ -38,10 +39,54 @@ $Configuration
 Examples:
 
 ```powershell
-# This rule uses a threshold stored as $Configuration.appServiceMinInstanceCount
+# Synopsis: This rule uses a threshold stored as $Configuration.appServiceMinInstanceCount
 Rule 'appServicePlan.MinInstanceCount' -If { $TargetObject.ResourceType -eq 'Microsoft.Web/serverfarms' } {
     $TargetObject.Sku.capacity -ge $Configuration.appServiceMinInstanceCount
 } -Configure @{ appServiceMinInstanceCount = 2 }
+```
+
+### LocalizedData
+
+A hashtable object with properties that map to localized data in a `.psd1` file.
+
+When using localized data, PSRule loads localized strings as a hashtable from `PSRule-rules.psd1`.
+
+The following logic is used to locate `PSRule-rules.psd1`:
+
+- If the rules are loose (not part of a module), PSRule will search for `PSRule-rules.psd1` in the `.\<culture>\` subdirectory relative to where the rule script _.ps1_ file is located.
+- When the rules are shipped as part of a module, PSRule will search for `PSRule-rules.psd1` in the `.\<culture>\` subdirectory relative to where the module manifest _.psd1_ file is located.
+
+When accessing localized data:
+
+- Property values are read only.
+- Property names are case sensitive.
+
+Syntax:
+
+```powershell
+$LocalizedData
+```
+
+Examples:
+
+```powershell
+# Data for rules stored in PSRule-rules.psd1
+@{
+    WithLocalizedDataMessage = 'LocalizedMessage for en-ZZ. Format={0}.'
+}
+```
+
+```powershell
+# Synopsis: Use -f to generate a formatted localized warning
+Rule 'WithLocalizedData' {
+    Write-Warning -Message ($LocalizedData.WithLocalizedDataMessage -f $TargetObject.Type)
+}
+```
+
+This rule returns a warning message similar to:
+
+```text
+LocalizedMessage for en-ZZ. Format=TestType.
 ```
 
 ### Rule

--- a/src/PSRule/Commands/NewRuleDefinitionCommand.cs
+++ b/src/PSRule/Commands/NewRuleDefinitionCommand.cs
@@ -68,7 +68,7 @@ namespace PSRule.Commands
             var context = PipelineContext.CurrentThread;
             var metadata = GetMetadata(MyInvocation.ScriptName, MyInvocation.ScriptLineNumber, MyInvocation.OffsetInLine);
             var tag = GetTag(Tag);
-            var moduleName = context.Source.ModuleName;
+            var source = context.Source;
 
             context.VerboseFoundRule(ruleName: Name, scriptName: MyInvocation.ScriptName);
 
@@ -102,13 +102,12 @@ namespace PSRule.Commands
             }
 
             var block = new RuleBlock(
-                sourcePath: MyInvocation.ScriptName,
-                moduleName: moduleName,
+                source: source,
                 ruleName: Name,
                 info: helpInfo,
                 condition: ps,
                 tag: tag,
-                dependsOn: RuleHelper.ExpandRuleName(DependsOn, MyInvocation.ScriptName, moduleName),
+                dependsOn: RuleHelper.ExpandRuleName(DependsOn, MyInvocation.ScriptName, source.ModuleName),
                 configuration: Configure
             );
 

--- a/src/PSRule/Host/Host.cs
+++ b/src/PSRule/Host/Host.cs
@@ -7,23 +7,73 @@ using System.Management.Automation.Runspaces;
 namespace PSRule.Host
 {
     /// <summary>
-    /// A dynamic variable used during Rule execution.
+    /// A dynamic variable $Rule used during Rule execution.
     /// </summary>
     internal sealed class RuleVariable : PSVariable
     {
-        private readonly Runtime.Rule _View;
+        private const string VARIABLE_NAME = "Rule";
 
-        public RuleVariable(string name)
-            : base(name, null, ScopedItemOptions.ReadOnly)
+        private readonly Runtime.Rule _Value;
+
+        public RuleVariable()
+            : base(VARIABLE_NAME, null, ScopedItemOptions.ReadOnly)
         {
-            _View = new Runtime.Rule();
+            _Value = new Runtime.Rule();
         }
 
         public override object Value
         {
             get
             {
-                return _View;
+                return _Value;
+            }
+        }
+    }
+
+    /// <summary>
+    /// A dynamic variable $LocalizedData used during Rule execution.
+    /// </summary>
+    internal sealed class LocalizedDataVariable : PSVariable
+    {
+        private const string VARIABLE_NAME = "LocalizedData";
+
+        private readonly Runtime.LocalizedData _Value;
+
+        public LocalizedDataVariable()
+            : base(VARIABLE_NAME, null, ScopedItemOptions.ReadOnly)
+        {
+            _Value = new Runtime.LocalizedData();
+        }
+
+        public override object Value
+        {
+            get
+            {
+                return _Value;
+            }
+        }
+    }
+
+    /// <summary>
+    /// An assertion helper variable $Assert used during Rule execution.
+    /// </summary>
+    internal sealed class AssertVariable : PSVariable
+    {
+        private const string VARIABLE_NAME = "Assert";
+
+        private readonly Runtime.Assert _Value;
+
+        public AssertVariable()
+            : base(VARIABLE_NAME, null, ScopedItemOptions.ReadOnly)
+        {
+            _Value = new Runtime.Assert();
+        }
+
+        public override object Value
+        {
+            get
+            {
+                return _Value;
             }
         }
     }
@@ -33,8 +83,10 @@ namespace PSRule.Host
     /// </summary>
     internal sealed class TargetObjectVariable : PSVariable
     {
-        public TargetObjectVariable(string name)
-            : base(name, null, ScopedItemOptions.ReadOnly)
+        private const string VARIABLE_NAME = "TargetObject";
+
+        public TargetObjectVariable()
+            : base(VARIABLE_NAME, null, ScopedItemOptions.ReadOnly)
         {
 
         }
@@ -50,10 +102,12 @@ namespace PSRule.Host
 
     internal sealed class ConfigurationVariable : PSVariable
     {
+        private const string VARIABLE_NAME = "Configuration";
+
         private readonly RuntimeRuleConfigurationView _Value;
 
-        public ConfigurationVariable(string name)
-            : base(name, null, ScopedItemOptions.ReadOnly)
+        public ConfigurationVariable()
+            : base(VARIABLE_NAME, null, ScopedItemOptions.ReadOnly)
         {
             _Value = new RuntimeRuleConfigurationView(); 
         }

--- a/src/PSRule/Host/HostHelper.cs
+++ b/src/PSRule/Host/HostHelper.cs
@@ -204,8 +204,8 @@ namespace PSRule.Host
                     {
                         RuleId = block.RuleId,
                         RuleName = block.RuleName,
-                        SourcePath = block.SourcePath,
-                        ModuleName = block.ModuleName,
+                        SourcePath = block.Source.Path,
+                        ModuleName = block.Source.ModuleName,
                         Tag = block.Tag,
                         Info = block.Info
                     };

--- a/src/PSRule/Pipeline/PipelineContext.cs
+++ b/src/PSRule/Pipeline/PipelineContext.cs
@@ -1,9 +1,10 @@
-using PSRule.Configuration;
+﻿using PSRule.Configuration;
 using PSRule.Host;
 using PSRule.Resources;
 using PSRule.Rules;
 using PSRule.Runtime;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Management.Automation;
@@ -52,6 +53,7 @@ namespace PSRule.Pipeline
         internal RuleBlock RuleBlock;
         internal PSRuleOption Option;
         internal RuleSource Source;
+        internal Dictionary<string, Hashtable> DataCache;
 
         public HashAlgorithm ObjectHashAlgorithm
         {
@@ -93,6 +95,7 @@ namespace PSRule.Pipeline
             }
 
             _NameTokenCache = new Dictionary<string, NameToken>();
+            DataCache = new Dictionary<string, Hashtable>();
         }
 
         public static PipelineContext New(ILogger logger, PSRuleOption option, BindTargetName bindTargetName, BindTargetName bindTargetType, bool logError = true, bool logWarning = true, bool logVerbose = false, bool logInformation = false)
@@ -279,9 +282,11 @@ namespace PSRule.Pipeline
                 }
 
                 _Runspace.Open();
-                _Runspace.SessionStateProxy.PSVariable.Set(new RuleVariable("Rule"));
-                _Runspace.SessionStateProxy.PSVariable.Set(new TargetObjectVariable("TargetObject"));
-                _Runspace.SessionStateProxy.PSVariable.Set(new ConfigurationVariable("Configuration"));
+                _Runspace.SessionStateProxy.PSVariable.Set(new RuleVariable());
+                _Runspace.SessionStateProxy.PSVariable.Set(new LocalizedDataVariable());
+                _Runspace.SessionStateProxy.PSVariable.Set(new AssertVariable());
+                _Runspace.SessionStateProxy.PSVariable.Set(new TargetObjectVariable());
+                _Runspace.SessionStateProxy.PSVariable.Set(new ConfigurationVariable());
                 _Runspace.SessionStateProxy.PSVariable.Set("ErrorActionPreference", ActionPreference.Continue);
                 _Runspace.SessionStateProxy.PSVariable.Set("WarningPreference", ActionPreference.Continue);
                 _Runspace.SessionStateProxy.PSVariable.Set("VerbosePreference", ActionPreference.Continue);
@@ -517,6 +522,7 @@ namespace PSRule.Pipeline
 
                     _RuleTimer.Stop();
                     _NameTokenCache.Clear();
+                    DataCache.Clear();
                 }
 
                 _Disposed = true;

--- a/src/PSRule/Rules/RuleBlock.cs
+++ b/src/PSRule/Rules/RuleBlock.cs
@@ -17,17 +17,16 @@ namespace PSRule.Rules
     [DebuggerDisplay("{RuleId} @{SourcePath}")]
     public sealed class RuleBlock : ILanguageBlock, IDependencyTarget, IDisposable
     {
-        internal RuleBlock(string sourcePath, string moduleName, string ruleName, RuleHelpInfo info, PowerShell condition, TagSet tag, string[] dependsOn, Hashtable configuration)
+        internal RuleBlock(RuleSource source, string ruleName, RuleHelpInfo info, PowerShell condition, TagSet tag, string[] dependsOn, Hashtable configuration)
         {
-            SourcePath = sourcePath;
-            ModuleName = moduleName;
+            Source = source;
             RuleName = ruleName;
 
-            var scriptFileName = Path.GetFileName(sourcePath);
+            var scriptFileName = Path.GetFileName(Source.Path);
 
             // Get either scriptFileName/RuleName or Module/scriptFileName/RuleName
-            RuleId = (ModuleName == null) ?
-                string.Concat(scriptFileName, '/', RuleName) : string.Concat(ModuleName, '/', scriptFileName, '/', RuleName);
+            RuleId = (Source.ModuleName == null) ?
+                string.Concat(scriptFileName, '/', RuleName) : string.Concat(Source.ModuleName, '/', scriptFileName, '/', RuleName);
 
             Info = info;
             Condition = condition;
@@ -49,12 +48,12 @@ namespace PSRule.Rules
         /// <summary>
         /// The script file path where the rule is defined.
         /// </summary>
-        public readonly string SourcePath;
+        //public readonly string SourcePath;
 
         /// <summary>
         /// The name of the module where the rule is defined, or null if the rule is not defined in a module.
         /// </summary>
-        public readonly string ModuleName;
+        //public readonly string ModuleName;
 
         /// <summary>
         /// A human readable block of text, used to identify the purpose of the rule.
@@ -96,9 +95,11 @@ namespace PSRule.Rules
 
         public readonly RuleHelpInfo Info;
 
-        string ILanguageBlock.SourcePath => SourcePath;
+        public readonly RuleSource Source;
 
-        string ILanguageBlock.Module => ModuleName;
+        string ILanguageBlock.SourcePath => Source.Path;
+
+        string ILanguageBlock.Module => Source.ModuleName;
 
         string IDependencyTarget.RuleId => RuleId;
 

--- a/src/PSRule/Runtime/Assert.cs
+++ b/src/PSRule/Runtime/Assert.cs
@@ -1,0 +1,9 @@
+﻿namespace PSRule.Runtime
+{
+    /// <summary>
+    /// A helper variable exposed at runtime for rules.
+    /// </summary>
+    public sealed class Assert
+    {
+    }
+}

--- a/src/PSRule/Runtime/LocalizedData.cs
+++ b/src/PSRule/Runtime/LocalizedData.cs
@@ -1,0 +1,71 @@
+﻿using PSRule.Pipeline;
+using System.Collections;
+using System.Dynamic;
+using System.IO;
+using System.Management.Automation.Language;
+
+namespace PSRule.Runtime
+{
+    public sealed class LocalizedData : DynamicObject
+    {
+        private static readonly Hashtable Empty = new Hashtable();
+
+        public override bool TryGetMember(GetMemberBinder binder, out object result)
+        {
+            var hashtable = TryGetLocalized();
+            
+            if (hashtable.ContainsKey(binder.Name))
+            {
+                result = hashtable[binder.Name];
+                return true;
+            }
+
+            result = null;
+            return false;
+        }
+
+        private Hashtable TryGetLocalized()
+        {
+            var path = GetFilePath();
+            
+            if (path == null)
+            {
+                return Empty;
+            }
+
+            if (PipelineContext.CurrentThread.DataCache.ContainsKey(path))
+            {
+                return PipelineContext.CurrentThread.DataCache[path];
+            }
+
+            var ast = System.Management.Automation.Language.Parser.ParseFile(fileName: path, out Token[] tokens, out ParseError[] errors);
+            var data = ast.Find(a => a is HashtableAst, false);
+
+            if (data != null)
+            {
+                var result = (Hashtable)data.SafeGetValue();
+                PipelineContext.CurrentThread.DataCache[path] = result;
+                return result;
+            }
+
+            return Empty;
+        }
+
+        private string GetFilePath()
+        {
+            var helpPath = PipelineContext.CurrentThread.RuleBlock.Source.HelpPath;
+
+            for (var i = 0; i < helpPath.Length; i++)
+            {
+                var path = Path.Combine(helpPath[i], "PSRule-rules.psd1");
+
+                if (File.Exists(path))
+                {
+                    return path;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/PSRule/Runtime/LocalizedData.cs
+++ b/src/PSRule/Runtime/LocalizedData.cs
@@ -38,7 +38,7 @@ namespace PSRule.Runtime
                 return PipelineContext.CurrentThread.DataCache[path];
             }
 
-            var ast = System.Management.Automation.Language.Parser.ParseFile(fileName: path, out Token[] tokens, out ParseError[] errors);
+            var ast = System.Management.Automation.Language.Parser.ParseFile(path, out Token[] tokens, out ParseError[] errors);
             var data = ast.Find(a => a is HashtableAst, false);
 
             if (data != null)

--- a/tests/PSRule.Tests/FromFile.Rule.ps1
+++ b/tests/PSRule.Tests/FromFile.Rule.ps1
@@ -136,6 +136,12 @@ Rule 'WithFormat' {
     ($TargetObject.spec.properties.array2 | Measure-Object).Count -eq 3
 }
 
+# Synopsis: Test $LocalizedData automatic variable
+Rule 'WithLocalizedData' {
+    Write-Warning -Message ($LocalizedData.WithLocalizedDataMessage -f $TargetObject.Type)
+    $LocalizedData.WithLocalizedDataMessage -like "LocalizedMessage for en-*"
+}
+
 Rule 'WithCsv' {
     $True;
 }

--- a/tests/PSRule.Tests/PSRule.Variables.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Variables.Tests.ps1
@@ -24,6 +24,8 @@ $here = (Resolve-Path $PSScriptRoot).Path;
 #region PSRule variables
 
 Describe 'PSRule variables' -Tag 'Variables' {
+    $ruleFilePath = (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1');
+
     Context 'PowerShell automatic variables' {
         $testObject = [PSCustomObject]@{
             Name = 'VariableTest'
@@ -32,10 +34,25 @@ Describe 'PSRule variables' -Tag 'Variables' {
         $testObject.PSObject.TypeNames.Insert(0, $testObject.Type);
 
         It '$Rule' {
-            $result = $testObject | Invoke-PSRule -Path (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1') -Name 'VariableTest';
+            $result = $testObject | Invoke-PSRule -Path $ruleFilePath -Name 'VariableTest';
             $result | Should -Not -BeNullOrEmpty;
             $result.IsSuccess() | Should -Be $True;
             $result.TargetName | Should -Be 'VariableTest';
+        }
+
+        It '$LocalizedData' {
+            $invokeParams = @{
+                Path = $ruleFilePath
+                Name = 'WithLocalizedData'
+                Culture = 'en-ZZ'
+                WarningAction = 'SilentlyContinue'
+            }
+            $result = $testObject | Invoke-PSRule @invokeParams -WarningVariable outWarning;
+            $messages = @($outwarning);
+            $result | Should -Not -BeNullOrEmpty;
+            $result.IsSuccess() | Should -Be $True;
+            $result.TargetName | Should -Be 'VariableTest';
+            $messages[0] | Should -Be 'LocalizedMessage for en-ZZ. Format=TestType.';
         }
     }
 }

--- a/tests/PSRule.Tests/en-ZZ/PSRule-rules.psd1
+++ b/tests/PSRule.Tests/en-ZZ/PSRule-rules.psd1
@@ -1,0 +1,4 @@
+# Data for rules
+@{
+    WithLocalizedDataMessage = 'LocalizedMessage for en-ZZ. Format={0}.'
+}


### PR DESCRIPTION
## PR Summary

- Add culture support for PowerShell informational messages. #158
  - A new `$LocalizedData` variable can be used within rule definitions.

Fixes #158 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/BernieWhite/PSRule/blob/master/CHANGELOG.md) has been updated with change under unreleased section
