### PR TITLE
Improve handling of rule tags and filtering #209 #204

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Add culture support for PowerShell informational messages. [#158](https://github.com/BernieWhite/PSRule/issues/158)
   - A new `$LocalizedData` variable can be used within rule definitions.
 - Add `-Not` switch to `Within` and `Match` keywords to allow negative comparison. [#208](https://github.com/BernieWhite/PSRule/issues/208)
+- Improve discovery of rule tags. [#209](https://github.com/BernieWhite/PSRule/issues/209)
+  - Add wide format `-OutputFormat Wide` to `Get-PSRule` to allow output of rule tags.
 
 ## v0.7.0-B190633 (pre-release)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Add `-Not` switch to `Within` and `Match` keywords to allow negative comparison. [#208](https://github.com/BernieWhite/PSRule/issues/208)
 - Improve discovery of rule tags. [#209](https://github.com/BernieWhite/PSRule/issues/209)
   - Add wide format `-OutputFormat Wide` to `Get-PSRule` to allow output of rule tags.
+- **Breaking change**: Change rule filtering by tag to be case-insensitive. [#204](https://github.com/BernieWhite/PSRule/issues/204)
+  - Previously tag value was case-sensitive, however this is confusing since PowerShell is case-insensitive by default.
 
 ## v0.7.0-B190633 (pre-release)
 

--- a/docs/commands/PSRule/en-US/Get-PSRule.md
+++ b/docs/commands/PSRule/en-US/Get-PSRule.md
@@ -31,12 +31,58 @@ Get-PSRule;
 ```
 
 ```text
-RuleName                            Description
---------                            -----------
-isFruit                             An example rule
+RuleName                            ModuleName                 Synopsis
+--------                            ----------                 --------
+isFruit                                                        An example rule
 ```
 
 Get a list of rule definitions from the current working path.
+
+### Example 2
+
+```powershell
+Get-PSRule -Module PSRule.Rules.Azure;
+```
+
+```text
+RuleName                            ModuleName                 Synopsis
+--------                            ----------                 --------
+Azure.ACR.AdminUser                 PSRule.Rules.Azure         Use Azure AD accounts instead of using the registry adm…
+Azure.ACR.MinSku                    PSRule.Rules.Azure         ACR should use the Premium or Standard SKU for producti…
+Azure.AKS.MinNodeCount              PSRule.Rules.Azure         AKS clusters should have minimum number of nodes for fa…
+Azure.AKS.Version                   PSRule.Rules.Azure         AKS clusters should meet the minimum version.
+Azure.AKS.UseRBAC                   PSRule.Rules.Azure         AKS cluster should use role-based access control (RBAC).
+```
+
+Get a list of rule definitions included in the module `PSRule.Rules.Azure`.
+
+### Example 3
+
+```powershell
+Get-PSRule -Module PSRule.Rules.Azure -OutputFormat Wide;
+```
+
+```text
+RuleName                            ModuleName                 Synopsis                     Tag
+--------                            ----------                 --------                     ---
+Azure.ACR.AdminUser                 PSRule.Rules.Azure         Use Azure AD accounts        severity='Critical'
+                                                               instead of using the         category='Security
+                                                               registry admin user.         configuration'
+Azure.ACR.MinSku                    PSRule.Rules.Azure         ACR should use the Premium   severity='Important'
+                                                               or Standard SKU for          category='Performance'
+                                                               production deployments.
+Azure.AKS.MinNodeCount              PSRule.Rules.Azure         AKS clusters should have     severity='Important'
+                                                               minimum number of nodes for  category='Reliability'
+                                                               failover and updates.
+Azure.AKS.Version                   PSRule.Rules.Azure         AKS clusters should meet     severity='Important'
+                                                               the minimum version.         category='Operations
+                                                                                            management'
+Azure.AKS.UseRBAC                   PSRule.Rules.Azure         AKS cluster should use       severity='Important'
+                                                               role-based access control    category='Security
+                                                               (RBAC).                      configuration'
+```
+
+Get a list of rule definitions included in the module `PSRule.Rules.Azure` including tags with line wrapping.
 
 ## PARAMETERS
 
@@ -80,7 +126,7 @@ Accept wildcard characters: False
 
 Only get rules with the specified tags set. If this parameter is not specified all rules in search paths will be returned.
 
-When more then one tag is used, all tags must match. Tag names are not case sensitive, tag values are case sensitive. A tag value of `*` may be used to filter rules to any rule with the tag set, regardless of tag value.
+When more than one tag is used, all tags must match. Tags are not case sensitive. A tag value of `*` may be used to filter rules to any rule with the tag set, regardless of tag value.
 
 ```yaml
 Type: Hashtable

--- a/docs/commands/PSRule/en-US/Get-PSRule.md
+++ b/docs/commands/PSRule/en-US/Get-PSRule.md
@@ -14,8 +14,8 @@ Get a list of rule definitions.
 ## SYNTAX
 
 ```text
-Get-PSRule [-Module <String[]>] [-ListAvailable] [[-Path] <String[]>] [-Name <String[]>] [-Tag <Hashtable>]
- [-Option <PSRuleOption>] [-Culture <String>] [<CommonParameters>]
+Get-PSRule [-Module <String[]>] [-ListAvailable] [-OutputFormat <OutputFormatGet>] [[-Path] <String[]>]
+ [-Name <String[]>] [-Tag <Hashtable>] [-Option <PSRuleOption>] [-Culture <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -160,6 +160,28 @@ The PowerShell cmdlet `Get-Culture` shows the current culture of PowerShell.
 Type: String
 Parameter Sets: (All)
 Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OutputFormat
+
+Configures the format that output is presented in.
+
+The following format options are available:
+
+- None - Output is presented as an object using PowerShell defaults. This is the default.
+- Wide - Output is presented using the wide table format, which includes tags and wraps columns.
+
+```yaml
+Type: OutputFormatGet
+Parameter Sets: (All)
+Aliases:
+Accepted values: None, Wide
 
 Required: False
 Position: Named

--- a/docs/commands/PSRule/en-US/Invoke-PSRule.md
+++ b/docs/commands/PSRule/en-US/Invoke-PSRule.md
@@ -175,7 +175,7 @@ Accept wildcard characters: False
 
 Only evaluate rules with the specified tags set. If this parameter is not specified all rules in search paths will be evaluated.
 
-When more than one tag is used, all tags must match. Tag names are not case sensitive, tag values are case sensitive. A tag value of `*` may be used to filter rules to any rule with the tag set, regardless of tag value.
+When more than one tag is used, all tags must match. Tags are not case sensitive. A tag value of `*` may be used to filter rules to any rule with the tag set, regardless of tag value.
 
 ```yaml
 Type: Hashtable

--- a/docs/commands/PSRule/en-US/Invoke-PSRule.md
+++ b/docs/commands/PSRule/en-US/Invoke-PSRule.md
@@ -335,6 +335,14 @@ Accept wildcard characters: False
 
 Configures the format that output is presented in.
 
+The following format options are available:
+
+- None - Output is presented as an object using PowerShell defaults. This is the default.
+- Yaml - Output is serialized as YAML.
+- Json - Output is serialized as JSON.
+- NUnit3 - Output is serialized as NUnit3 (XML).
+- Csv - Output is serialized as a comma separated values (CSV).
+
 ```yaml
 Type: OutputFormat
 Parameter Sets: (All)

--- a/docs/commands/PSRule/en-US/Test-PSRuleTarget.md
+++ b/docs/commands/PSRule/en-US/Test-PSRuleTarget.md
@@ -94,7 +94,7 @@ Accept wildcard characters: False
 
 Only evaluate rules with the specified tags set. If this parameter is not specified all rules in search paths will be evaluated.
 
-When more than one tag is used, all tags must match. Tag names are not case sensitive, tag values are case sensitive. A tag value of `*` may be used to filter rules to any rule with the tag set, regardless of tag value.
+When more than one tag is used, all tags must match. Tags are not case sensitive. A tag value of `*` may be used to filter rules to any rule with the tag set, regardless of tag value.
 
 ```yaml
 Type: Hashtable

--- a/docs/concepts/PSRule/en-US/about_PSRule_Options.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Options.md
@@ -625,11 +625,11 @@ output:
 
 ### Output.Format
 
-Configures the format that results will be presented in.
+Configures the format that results will be presented in. This option only applies to output generated from `Invoke-PSRule`.
 
 The following format options are available:
 
-- None - Output is presented as an object using PowerShell defaults. This is the default configuration.
+- None - Output is presented as an object using PowerShell defaults. This is the default.
 - Yaml - Output is serialized as YAML.
 - Json - Output is serialized as JSON.
 - NUnit3 - Output is serialized as NUnit3 (XML).

--- a/src/PSRule/Configuration/OutputFormat.cs
+++ b/src/PSRule/Configuration/OutputFormat.cs
@@ -16,4 +16,12 @@ namespace PSRule.Configuration
 
         Csv = 4
     }
+
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum OutputFormatGet : byte
+    {
+        None = 0,
+
+        Wide = 5
+    }
 }

--- a/src/PSRule/PSRule.Format.ps1xml
+++ b/src/PSRule/PSRule.Format.ps1xml
@@ -103,10 +103,11 @@
             <Width>35</Width>
           </TableColumnHeader>
           <TableColumnHeader>
-            <Label AssemblyName="PSRule" BaseName="PSRule.Resources.ViewStrings" ResourceId="Synopsis"/>
+            <Label AssemblyName="PSRule" BaseName="PSRule.Resources.ViewStrings" ResourceId="ModuleName"/>
+            <Width>26</Width>
           </TableColumnHeader>
           <TableColumnHeader>
-            <Label AssemblyName="PSRule" BaseName="PSRule.Resources.ViewStrings" ResourceId="ModuleName"/>
+            <Label AssemblyName="PSRule" BaseName="PSRule.Resources.ViewStrings" ResourceId="Synopsis"/>
           </TableColumnHeader>
         </TableHeaders>
         <TableRowEntries>
@@ -116,10 +117,53 @@
               <PropertyName>RuleName</PropertyName>
               </TableColumnItem>
               <TableColumnItem>
+                <PropertyName>ModuleName</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
                 <PropertyName>Synopsis</PropertyName>
+              </TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
+    <View>
+      <Name>PSRule.Rules.Rule+Wide</Name>
+      <ViewSelectedBy>
+        <TypeName>PSRule.Rules.Rule+Wide</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <TableHeaders>
+          <TableColumnHeader>
+            <Label AssemblyName="PSRule" BaseName="PSRule.Resources.ViewStrings" ResourceId="RuleName"/>
+            <Width>35</Width>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label AssemblyName="PSRule" BaseName="PSRule.Resources.ViewStrings" ResourceId="ModuleName"/>
+            <Width>26</Width>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label AssemblyName="PSRule" BaseName="PSRule.Resources.ViewStrings" ResourceId="Synopsis"/>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label AssemblyName="PSRule" BaseName="PSRule.Resources.ViewStrings" ResourceId="Tag"/>
+          </TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <Wrap/>
+            <TableColumnItems>
+              <TableColumnItem>
+                <PropertyName>RuleName</PropertyName>
               </TableColumnItem>
               <TableColumnItem>
                 <PropertyName>ModuleName</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Synopsis</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <ScriptBlock>$_.Tag.ToViewString()</ScriptBlock>
               </TableColumnItem>
             </TableColumnItems>
           </TableRowEntry>
@@ -152,7 +196,7 @@
           <TableRowEntry>
             <TableColumnItems>
               <TableColumnItem>
-              <PropertyName>RuleName</PropertyName>
+                <PropertyName>RuleName</PropertyName>
               </TableColumnItem>
               <TableColumnItem>
                 <PropertyName>Outcome</PropertyName>

--- a/src/PSRule/PSRule.psm1
+++ b/src/PSRule/PSRule.psm1
@@ -352,6 +352,10 @@ function Get-PSRule {
         [Parameter(Mandatory = $False)]
         [Switch]$ListAvailable,
 
+        [Parameter(Mandatory = $False)]
+        [ValidateSet('None', 'Wide')]
+        [PSRule.Configuration.OutputFormatGet]$OutputFormat,
+
         # A list of paths to check for rule definitions
         [Parameter(Position = 0, Mandatory = $False)]
         [Alias('p')]
@@ -441,7 +445,15 @@ function Get-PSRule {
         if ($Null -ne (Get-Variable -Name pipeline -ErrorAction SilentlyContinue)) {
             try {
                 # Get matching rule definitions
-                $pipeline.Process();
+                foreach ($item in $pipeline.Process()) {
+                    if ($OutputFormat -eq [PSRule.Configuration.OutputFormatGet]::Wide) {
+                        $item.PSObject.TypeNames.Insert(0, 'PSRule.Rules.Rule+Wide');
+                        $item;
+                    }
+                    else {
+                        $item;
+                    }
+                }
             }
             catch {
                 $pipeline.Dispose();

--- a/src/PSRule/Resources/ViewStrings.Designer.cs
+++ b/src/PSRule/Resources/ViewStrings.Designer.cs
@@ -160,6 +160,15 @@ namespace PSRule.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Tag.
+        /// </summary>
+        internal static string Tag {
+            get {
+                return ResourceManager.GetString("Tag", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to TargetName.
         /// </summary>
         internal static string TargetName {

--- a/src/PSRule/Resources/ViewStrings.resx
+++ b/src/PSRule/Resources/ViewStrings.resx
@@ -150,6 +150,9 @@
   <data name="Synopsis" xml:space="preserve">
     <value>Synopsis</value>
   </data>
+  <data name="Tag" xml:space="preserve">
+    <value>Tag</value>
+  </data>
   <data name="TargetName" xml:space="preserve">
     <value>TargetName</value>
   </data>

--- a/src/PSRule/Rules/TagSet.cs
+++ b/src/PSRule/Rules/TagSet.cs
@@ -8,18 +8,18 @@ namespace PSRule.Rules
 {
     public sealed class TagSet : DynamicObject
     {
-        private readonly IEqualityComparer<string> _Comparer;
+        private readonly IEqualityComparer<string> _ValueComparer;
         private readonly Dictionary<string, string> _Tag;
 
         public TagSet()
         {
-            _Comparer = StringComparer.Ordinal;
+            _ValueComparer = StringComparer.OrdinalIgnoreCase;
             _Tag = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         }
 
         private TagSet(Dictionary<string, string> tag)
         {
-            _Comparer = StringComparer.Ordinal;
+            _ValueComparer = StringComparer.OrdinalIgnoreCase;
             _Tag = tag;
         }
 
@@ -41,7 +41,7 @@ namespace PSRule.Rules
                 return true;
             }
 
-            return _Comparer.Equals(v, _Tag[k]);
+            return _ValueComparer.Equals(v, _Tag[k]);
         }
 
         public static TagSet FromHashtable(Hashtable hashtable)

--- a/src/PSRule/Rules/TagSet.cs
+++ b/src/PSRule/Rules/TagSet.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Dynamic;
+using System.Text;
 
 namespace PSRule.Rules
 {
@@ -73,6 +74,29 @@ namespace PSRule.Rules
         public Hashtable ToHashtable()
         {
             return new Hashtable(_Tag, StringComparer.OrdinalIgnoreCase);
+        }
+
+        public string ToViewString()
+        {
+            var sb = new StringBuilder();
+            var i = 0;
+
+            foreach (var kv in _Tag)
+            {
+                if (i > 0)
+                {
+                    sb.Append(Environment.NewLine);
+                }
+
+                sb.Append(kv.Key.ToString());
+                sb.Append('=');
+                sb.Append('\'');
+                sb.Append(kv.Value.ToString());
+                sb.Append('\'');
+                i++;
+            }
+
+            return sb.ToString();
         }
 
         public bool ContainsKey(string key)

--- a/tests/PSRule.Tests/PSRule.Common.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Common.Tests.ps1
@@ -124,10 +124,10 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
             $result.Tag.feature | Should -BeIn 'tag';
 
             # Ensure that tag selection is and'ed together, requiring all tags to be selected
-            # Tag values, will be matched without case sensitivity, but values are case sensitive
+            # Tag values, will be matched without case sensitivity
             $result = $testObject | Invoke-PSRule -Path $ruleFilePath -Tag @{ feature = 'tag'; severity = 'critical'; };
             $result | Should -Not -BeNullOrEmpty;
-            $result.Count | Should -Be 2;
+            $result.Count | Should -Be 3;
             $result.Tag.feature | Should -BeIn 'tag';
 
             # Using a * wildcard in tag filter, matches rules with the tag regardless of value 


### PR DESCRIPTION
## PR Summary

- Improve discovery of rule tags. #209
  - Add wide format `-OutputFormat Wide` to `Get-PSRule` to allow output of rule tags. 
- **Breaking change**: Change rule filtering by tag to be case-insensitive. #204
  - Previously tag value was case-sensitive, however this is confusing since PowerShell is case-insensitive by default.

Fixes #209 
Fixes #204 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/BernieWhite/PSRule/blob/master/CHANGELOG.md) has been updated with change under unreleased section
