### PR TITLE
Fix Within comparison of non-string types #226

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## Unreleased
 
 - Fix reading nested arrays from JSON input. [#223](https://github.com/BernieWhite/PSRule/issues/223)
+- Fix comparison of non-string types with `Within`. [#226](https://github.com/BernieWhite/PSRule/issues/226)
 
 ## v0.7.0-B190652 (pre-release)
 

--- a/src/PSRule/Commands/AssertWithinCommand.cs
+++ b/src/PSRule/Commands/AssertWithinCommand.cs
@@ -60,7 +60,7 @@ namespace PSRule.Commands
                             match = true;
                         }
                     }
-                    else if (Value[i] == fieldValue)
+                    else if (Value[i]?.BaseObject == fieldValue)
                     {
                         match = true;
                     }

--- a/tests/PSRule.Tests/FromFile.Rule.ps1
+++ b/tests/PSRule.Tests/FromFile.Rule.ps1
@@ -214,6 +214,11 @@ Rule 'WithinNot' {
     Within 'Title' 'Mr', 'Sir' -Not
 }
 
+Rule 'WithinTypes' {
+    Within 'BooleanValue' $True
+    Within 'IntValue' 0, 1, 2, 3
+}
+
 # Synopsis: Test for Match keyword
 Rule 'MatchTest' -Tag @{ keyword = 'Match' } {
     AnyOf {

--- a/tests/PSRule.Tests/PSRule.Within.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Within.Tests.ps1
@@ -39,6 +39,19 @@ Describe 'PSRule -- Within keyword' -Tag 'Within' {
             $result[2].IsSuccess() | Should -Be $True;
             $result[3].IsSuccess() | Should -Be $True;
             $result[4].IsSuccess() | Should -Be $False;
+
+            # Check non-string types
+            $testObject = @(
+                [PSCustomObject]@{ BooleanValue = $True; IntValue = 1 }
+                [PSCustomObject]@{ BooleanValue = $False; IntValue = 100 }
+            )
+
+            $result = $testObject | Invoke-PSRule -Path $ruleFilePath -Name 'WithinTypes' -Outcome All;
+            $result | Should -Not -BeNullOrEmpty;
+            $result.Count | Should -Be 2;
+            $result.RuleName | Should -BeIn 'WithinTypes';
+            $result[0].IsSuccess() | Should -Be $True;
+            $result[1].IsSuccess() | Should -Be $False;
         }
 
         It 'With -CaseSensitive' {


### PR DESCRIPTION
## PR Summary

- Fix comparison of non-string types with `Within`. #226

Fixes #226 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/BernieWhite/PSRule/blob/master/CHANGELOG.md) has been updated with change under unreleased section
