### PR TITLE
Fix YAML options discovery and display #232 #233

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 
 ## Unreleased
 
+- Fix YAML options file discovery issue in dotted directory. [#232](https://github.com/BernieWhite/PSRule/issues/232)
+- PSRule options are now displayed as YAML instead of complex object. [#233](https://github.com/BernieWhite/PSRule/issues/233)
+
 ## v0.7.0
 
 What's changed since v0.6.0:

--- a/src/PSRule/PSRule.Format.ps1xml
+++ b/src/PSRule/PSRule.Format.ps1xml
@@ -89,6 +89,26 @@
         </CustomEntries>
       </CustomControl>
     </Control>
+    <Control>
+      <Name>Option-Yaml</Name>
+      <CustomControl>
+        <CustomEntries>
+          <CustomEntry>
+              <CustomItem>
+                <Text AssemblyName="PSRule" BaseName="PSRule.Resources.ViewStrings" ResourceId="OptionsComment"/>
+                <NewLine />
+                <Frame>
+                  <CustomItem>
+                    <ExpressionBinding>
+                      <ScriptBlock>$_.ToYaml();</ScriptBlock>
+                    </ExpressionBinding>
+                  </CustomItem>
+                </Frame>
+              </CustomItem>
+            </CustomEntry>
+        </CustomEntries>
+      </CustomControl>
+    </Control>
   </Controls>
   <ViewDefinitions>
     <View>
@@ -328,6 +348,23 @@
           </TableRowEntry>
         </TableRowEntries>
       </TableControl>
+    </View>
+    <View>
+      <Name>PSRule.Configuration.PSRuleOption</Name>
+      <ViewSelectedBy>
+        <TypeName>PSRule.Configuration.PSRuleOption</TypeName>
+      </ViewSelectedBy>
+      <CustomControl>
+         <CustomEntries>
+              <CustomEntry>
+                <CustomItem>
+                  <ExpressionBinding>
+                    <CustomControlName>Option-Yaml</CustomControlName>
+                  </ExpressionBinding>
+                </CustomItem>
+              </CustomEntry>
+            </CustomEntries>
+      </CustomControl>
     </View>
   </ViewDefinitions>
 </Configuration>

--- a/src/PSRule/Resources/PSRuleResources.Designer.cs
+++ b/src/PSRule/Resources/PSRuleResources.Designer.cs
@@ -124,6 +124,15 @@ namespace PSRule.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to # Source: {0}.
+        /// </summary>
+        internal static string OptionsSourceComment {
+            get {
+                return ResourceManager.GetString("OptionsSourceComment", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to [FAIL] -- {0}:: Reported for &apos;{1}&apos;.
         /// </summary>
         internal static string OutcomeRuleFail {

--- a/src/PSRule/Resources/PSRuleResources.resx
+++ b/src/PSRule/Resources/PSRuleResources.resx
@@ -143,6 +143,9 @@
     <value>Options file does not exist.</value>
     <comment>Occurs when explicit path to a YAML file is specified and doesn't exist.</comment>
   </data>
+  <data name="OptionsSourceComment" xml:space="preserve">
+    <value># Source: {0}</value>
+  </data>
   <data name="OutcomeRuleFail" xml:space="preserve">
     <value>[FAIL] -- {0}:: Reported for '{1}'</value>
   </data>

--- a/src/PSRule/Resources/ViewStrings.Designer.cs
+++ b/src/PSRule/Resources/ViewStrings.Designer.cs
@@ -106,6 +106,15 @@ namespace PSRule.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to # PSRule options.
+        /// </summary>
+        internal static string OptionsComment {
+            get {
+                return ResourceManager.GetString("OptionsComment", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Outcome.
         /// </summary>
         internal static string Outcome {

--- a/src/PSRule/Resources/ViewStrings.resx
+++ b/src/PSRule/Resources/ViewStrings.resx
@@ -132,6 +132,9 @@
   <data name="Name" xml:space="preserve">
     <value>Name</value>
   </data>
+  <data name="OptionsComment" xml:space="preserve">
+    <value># PSRule options</value>
+  </data>
   <data name="Outcome" xml:space="preserve">
     <value>Outcome</value>
   </data>

--- a/tests/PSRule.Tests/PSRule.Options.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Options.Tests.ps1
@@ -30,6 +30,30 @@ $Null = New-Item -Path $outputPath -ItemType Directory -Force;
 Describe 'New-PSRuleOption' -Tag 'Option','New-PSRuleOption' {
     $emptyOptionsFilePath = (Join-Path -Path $here -ChildPath 'PSRule.Tests4.yml');
 
+    Context 'Use -Path' {
+        It 'With file' {
+            $filePath = Join-Path -Path $outputPath -ChildPath 'new.file/ps-rule.yaml';
+            Set-PSRuleOption -Path $filePath -Force;
+            { New-PSRuleOption -Path $filePath -ErrorAction Stop } | Should -Not -Throw;
+        }
+
+        It 'With directory' {
+            $filePath = Join-Path -Path $outputPath -ChildPath 'new.file';
+            Set-PSRuleOption -Path $filePath -Force;
+            { New-PSRuleOption -Path $filePath -ErrorAction Stop } | Should -Not -Throw;
+        }
+
+        It 'With missing file' {
+            $filePath = (Join-Path -Path $outputPath -ChildPath 'new-not-a-file.yaml');
+            { New-PSRuleOption -Path $filePath -ErrorAction Stop } | Should -Throw;
+        }
+
+        It 'With missing directory' {
+            $filePath = (Join-Path -Path $outputPath -ChildPath 'new-dir/ps-rule.yaml');
+            { New-PSRuleOption -Path $filePath -ErrorAction Stop } | Should -Throw;
+        }
+    }
+
     Context 'Read Baseline.RuleName' {
         It 'from default' {
             $option = New-PSRuleOption;
@@ -493,19 +517,19 @@ Describe 'Set-PSRuleOption' -Tag 'Option','Set-PSRuleOption' {
 
     Context 'Use -Path' {
         It 'With missing file' {
-            $filePath = (Join-Path -Path $outputPath -ChildPath 'not-a-file.yml');
+            $filePath = (Join-Path -Path $outputPath -ChildPath 'set-not-a-file.yml');
             { Set-PSRuleOption -Path $filePath -ErrorAction Stop } | Should -Not -Throw;
             Test-Path -Path $filePath | Should -Be $True;
         }
 
         It 'With missing directory' {
-            $filePath = (Join-Path -Path $outputPath -ChildPath 'dir/ps-rule.yaml');
+            $filePath = (Join-Path -Path $outputPath -ChildPath 'set-dir/ps-rule.yaml');
             { Set-PSRuleOption -Path $filePath -ErrorAction Stop } | Should -Throw -ErrorId 'PSRule.PSRuleOption.ParentPathNotFound';
             Test-Path -Path $filePath | Should -Be $False;
         }
 
         It 'With missing directory with -Force' {
-            $filePath = (Join-Path -Path $outputPath -ChildPath 'dir/ps-rule.yaml');
+            $filePath = (Join-Path -Path $outputPath -ChildPath 'set-dir/ps-rule.yaml');
             Set-PSRuleOption -Path $filePath -Force;
             Test-Path -Path $filePath | Should -Be $True;
         }


### PR DESCRIPTION
## PR Summary

- Fix YAML options file discovery issue in dotted directory. #232
- PSRule options are now displayed as YAML instead of complex object. #233 

Fixes #232 
Fixes #233 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/BernieWhite/PSRule/blob/master/CHANGELOG.md) has been updated with change under unreleased section
