### PR TITLE
Add debug messages and verbose limiting #146 #235

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 - Fix YAML options file discovery issue in dotted directory. [#232](https://github.com/BernieWhite/PSRule/issues/232)
 - PSRule options are now displayed as YAML instead of complex object. [#233](https://github.com/BernieWhite/PSRule/issues/233)
+- Add support for debug messages and `Write-Debug` in rule definitions. [#146](https://github.com/BernieWhite/PSRule/issues/146)
+- Added `Logging.LimitDebug` and `Logging.LimitVerbose` options to limit logging to named scopes. [#235](https://github.com/BernieWhite/PSRule/issues/235)
 
 ## v0.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## Unreleased
 
 - Fix YAML options file discovery issue in dotted directory. [#232](https://github.com/BernieWhite/PSRule/issues/232)
+- Fix comparison of wrapped types and null with `Within`. [#237](https://github.com/BernieWhite/PSRule/issues/237)
 - PSRule options are now displayed as YAML instead of complex object. [#233](https://github.com/BernieWhite/PSRule/issues/233)
 - Add support for debug messages and `Write-Debug` in rule definitions. [#146](https://github.com/BernieWhite/PSRule/issues/146)
 - Added `Logging.LimitDebug` and `Logging.LimitVerbose` options to limit logging to named scopes. [#235](https://github.com/BernieWhite/PSRule/issues/235)

--- a/README.md
+++ b/README.md
@@ -188,6 +188,8 @@ The following conceptual topics exist in the `PSRule` module:
   - [Execution.NotProcessedWarning](docs/concepts/PSRule/en-US/about_PSRule_Options.md#not-processed-warning)
   - [Input.Format](docs/concepts/PSRule/en-US/about_PSRule_Options.md#inputformat)
   - [Input.ObjectPath](docs/concepts/PSRule/en-US/about_PSRule_Options.md#inputobjectpath)
+  - [Logging.LimitDebug](docs/concepts/PSRule/en-US/about_PSRule_Options.md#logginglimitdebug)
+  - [Logging.LimitVerbose](docs/concepts/PSRule/en-US/about_PSRule_Options.md#logginglimitverbose)
   - [Logging.RuleFail](docs/concepts/PSRule/en-US/about_PSRule_Options.md#loggingrulefail)
   - [Logging.RulePass](docs/concepts/PSRule/en-US/about_PSRule_Options.md#loggingrulepass)
   - [Output.As](docs/concepts/PSRule/en-US/about_PSRule_Options.md#outputas)

--- a/docs/commands/PSRule/en-US/New-PSRuleOption.md
+++ b/docs/commands/PSRule/en-US/New-PSRuleOption.md
@@ -18,9 +18,10 @@ New-PSRuleOption [[-Path] <String>] [[-Option] <PSRuleOption>] [-BaselineConfigu
  [-SuppressTargetName <SuppressionOption>] [-BindTargetName <BindTargetName[]>]
  [-BindTargetType <BindTargetName[]>] [-BindingIgnoreCase <Boolean>] [-TargetName <String[]>]
  [-TargetType <String[]>] [-InconclusiveWarning <Boolean>] [-NotProcessedWarning <Boolean>]
- [-Format <InputFormat>] [-ObjectPath <String>] [-LoggingRuleFail <OutcomeLogStream>]
- [-LoggingRulePass <OutcomeLogStream>] [-OutputAs <ResultFormat>] [-OutputEncoding <OutputEncoding>]
- [-OutputFormat <OutputFormat>] [-OutputPath <String>] [<CommonParameters>]
+ [-Format <InputFormat>] [-ObjectPath <String>] [-LoggingLimitDebug <String[]>]
+ [-LoggingLimitVerbose <String[]>] [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>]
+ [-OutputAs <ResultFormat>] [-OutputEncoding <OutputEncoding>] [-OutputFormat <OutputFormat>]
+ [-OutputPath <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -292,6 +293,38 @@ Sets the `Input.ObjectPath` option to use an object path to use instead of the p
 Type: String
 Parameter Sets: (All)
 Aliases: InputObjectPath
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -LoggingLimitDebug
+
+Sets the `Logging.LimitDebug` option to limit debug messages to a list of named debug scopes.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -LoggingLimitVerbose
+
+Sets the `Logging.LimitVerbose` option to limit verbose messages to a list of named verbose scopes.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
 
 Required: False
 Position: Named

--- a/docs/commands/PSRule/en-US/Set-PSRuleOption.md
+++ b/docs/commands/PSRule/en-US/Set-PSRuleOption.md
@@ -17,9 +17,10 @@ Sets options that configure PSRule execution.
 Set-PSRuleOption [[-Path] <String>] [-Option <PSRuleOption>] [-PassThru] [-Force] [-AllowClobber]
  [-BindingIgnoreCase <Boolean>] [-TargetName <String[]>] [-TargetType <String[]>]
  [-InconclusiveWarning <Boolean>] [-NotProcessedWarning <Boolean>] [-Format <InputFormat>]
- [-ObjectPath <String>] [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>]
- [-OutputAs <ResultFormat>] [-OutputEncoding <OutputEncoding>] [-OutputFormat <OutputFormat>]
- [-OutputPath <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-ObjectPath <String>] [-LoggingLimitDebug <String[]>] [-LoggingLimitVerbose <String[]>]
+ [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>] [-OutputAs <ResultFormat>]
+ [-OutputEncoding <OutputEncoding>] [-OutputFormat <OutputFormat>] [-OutputPath <String>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -237,6 +238,38 @@ Sets the `Input.ObjectPath` option to use an object path to use instead of the p
 Type: String
 Parameter Sets: (All)
 Aliases: InputObjectPath
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -LoggingLimitDebug
+
+Sets the `Logging.LimitDebug` option to limit debug messages to a list of named debug scopes.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -LoggingLimitVerbose
+
+Sets the `Logging.LimitVerbose` option to limit verbose messages to a list of named verbose scopes.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
 
 Required: False
 Position: Named

--- a/docs/concepts/PSRule/en-US/about_PSRule_Options.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Options.md
@@ -23,6 +23,8 @@ The following options are available for use:
 - [Execution.NotProcessedWarning](#not-processed-warning)
 - [Input.Format](#inputformat)
 - [Input.ObjectPath](#inputobjectpath)
+- [Logging.LimitDebug](#logginglimitdebug)
+- [Logging.LimitVerbose](#logginglimitverbose)
 - [Logging.RuleFail](#loggingrulefail)
 - [Logging.RulePass](#loggingrulepass)
 - [Output.As](#outputas)
@@ -477,6 +479,82 @@ input:
   objectPath: items
 ```
 
+### Logging.LimitDebug
+
+Limits debug messages to a list of named debug scopes.
+
+When using the `-Debug` switch or preference variable, by default PSRule cmdlets log all debug output. When using debug output for debugging a specific rule, it my be helpful to limit debug message to a specific rule.
+
+To identify a rule to include in debug output use the rule name.
+
+The following built-in scopes exist in addition to rule names:
+
+- `[Discovery.Source]` - Discovery messages for `.Rule.ps1` files and rule modules.
+- `[Discovery.Rule]` - Discovery messages for individual rules within `.Rule.ps1` files.
+
+This option can be specified using:
+
+```powershell
+# PowerShell: Using the LoggingLimitDebug parameter
+$option = New-PSRuleOption -LoggingLimitDebug Rule1, Rule2;
+```
+
+```powershell
+# PowerShell: Using the Logging.LimitDebug hashtable key
+$option = New-PSRuleOption -Option @{ 'Logging.LimitDebug' = Rule1, Rule2 };
+```
+
+```powershell
+# PowerShell: Using the LoggingLimitDebug parameter to set YAML
+Set-PSRuleOption -LoggingLimitDebug Rule1, Rule2;
+```
+
+```yaml
+# YAML: Using the logging/limitDebug property
+logging:
+  limitDebug:
+  - Rule1
+  - Rule2
+```
+
+### Logging.LimitVerbose
+
+Limits verbose messages to a list of named verbose scopes.
+
+When using the `-Verbose` switch or preference variable, by default PSRule cmdlets log all verbose output. When using verbose output for troubleshooting a specific rule, it may be helpful to limit verbose messages to a specific rule.
+
+To identify a rule to include in verbose output use the rule name.
+
+The following built-in scopes exist in addition to rule names:
+
+- `[Discovery.Source]` - Discovery messages for `.Rule.ps1` files and rule modules.
+- `[Discovery.Rule]` - Discovery messages for individual rules within `.Rule.ps1` files.
+
+This option can be specified using:
+
+```powershell
+# PowerShell: Using the LoggingLimitVerbose parameter
+$option = New-PSRuleOption -LoggingLimitVerbose Rule1, Rule2;
+```
+
+```powershell
+# PowerShell: Using the Logging.LimitVerbose hashtable key
+$option = New-PSRuleOption -Option @{ 'Logging.LimitVerbose' = Rule1, Rule2 };
+```
+
+```powershell
+# PowerShell: Using the LoggingLimitVerbose parameter to set YAML
+Set-PSRuleOption -LoggingLimitVerbose Rule1, Rule2;
+```
+
+```yaml
+# YAML: Using the logging/limitVerbose property
+logging:
+  limitVerbose:
+  - Rule1
+  - Rule2
+```
+
 ### Logging.RuleFail
 
 When an object fails a rule condition the results are written to output as a structured object marked with the outcome of _Fail_. If the rule executed successfully regardless of outcome no other informational messages are shown by default.
@@ -796,6 +874,12 @@ input:
 
 # Configures outcome logging options
 logging:
+  limitDebug:
+  - Rule1
+  - Rule2
+  limitVerbose:
+  - Rule1
+  - Rule2
   ruleFail: Error
   rulePass: Information
 
@@ -848,6 +932,8 @@ input:
 
 # Configures outcome logging options
 logging:
+  limitDebug: [ ]
+  limitVerbose: [ ]
   ruleFail: None
   rulePass: None
 

--- a/schemas/PSRule-options.schema.json
+++ b/schemas/PSRule-options.schema.json
@@ -4,7 +4,7 @@
     "description": "A schema for PSRule YAML options files.",
     "oneOf": [
         {
-            "$ref": "#/definitions/options-v0.7.0"
+            "$ref": "#/definitions/options-v0.8.0"
         }
     ],
     "definitions": {
@@ -109,10 +109,26 @@
             },
             "additionalProperties": false
         },
-        "logging-v0.5.0": {
+        "logging-v0.8.0": {
             "type": "object",
             "description": "Options for logging outcomes to a informational streams.",
             "properties": {
+                "limitDebug": {
+                    "type": "array",
+                    "description": "Limits debug messages to a list of named debug scopes.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "uniqueItems": true
+                },
+                "limitVerbose": {
+                    "type": "array",
+                    "description": "Limits verbose messages to a list of named verbose scopes.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "uniqueItems": true
+                },
                 "ruleFail": {
                     "type": "string",
                     "description": "Log fail outcomes for each rule to a specific informational stream.",
@@ -187,7 +203,7 @@
             },
             "additionalProperties": false
         },
-        "options-v0.7.0": {
+        "options-v0.8.0": {
             "properties": {
                 "baseline": {
                     "type": "object",
@@ -225,7 +241,7 @@
                     "type": "object",
                     "oneOf": [
                         {
-                            "$ref": "#/definitions/logging-v0.5.0"
+                            "$ref": "#/definitions/logging-v0.8.0"
                         }
                     ]
                 },

--- a/src/PSRule/Commands/AssertExistsCommand.cs
+++ b/src/PSRule/Commands/AssertExistsCommand.cs
@@ -43,13 +43,13 @@ namespace PSRule.Commands
 
                 if (expected && actual == expected)
                 {
-                    PipelineContext.CurrentThread.WriteVerbose($"[Exists] -- The field {Field[i]} exists");
+                    PipelineContext.CurrentThread.VerboseConditionMessage(condition: RuleLanguageNouns.Exists, message: $"The field {Field[i]} exists");
                 }
             }
 
             if (!actual)
             {
-                PipelineContext.CurrentThread.WriteVerbose($"[Exists] -- The field(s) {string.Join(", ", Field)} do not exist");
+                PipelineContext.CurrentThread.VerboseConditionMessage(condition: RuleLanguageNouns.Exists, message: $"The field(s) {string.Join(", ", Field)} do not exist");
             }
 
             WriteObject(expected == actual);

--- a/src/PSRule/Commands/AssertExistsCommand.cs
+++ b/src/PSRule/Commands/AssertExistsCommand.cs
@@ -1,4 +1,5 @@
 ﻿using PSRule.Pipeline;
+using PSRule.Resources;
 using PSRule.Runtime;
 using System.Management.Automation;
 
@@ -41,17 +42,14 @@ namespace PSRule.Commands
             {
                 actual = ObjectHelper.GetField(bindingContext: PipelineContext.CurrentThread, targetObject: targetObject, name: Field[i], caseSensitive: CaseSensitive, value: out object fieldValue);
 
-                if (expected && actual == expected)
+                if (actual)
                 {
-                    PipelineContext.CurrentThread.VerboseConditionMessage(condition: RuleLanguageNouns.Exists, message: $"The field {Field[i]} exists");
+                    PipelineContext.CurrentThread.VerboseConditionMessage(condition: RuleLanguageNouns.Exists, message: PSRuleResources.ExistsTrue, args: Field[i]);
                 }
             }
 
-            if (!actual)
-            {
-                PipelineContext.CurrentThread.VerboseConditionMessage(condition: RuleLanguageNouns.Exists, message: $"The field(s) {string.Join(", ", Field)} do not exist");
-            }
-
+            var result = expected == actual;
+            PipelineContext.CurrentThread.VerboseConditionResult(condition: RuleLanguageNouns.Exists, outcome: result);
             WriteObject(expected == actual);
         }
     }

--- a/src/PSRule/Commands/AssertMatchCommand.cs
+++ b/src/PSRule/Commands/AssertMatchCommand.cs
@@ -1,4 +1,5 @@
 ﻿using PSRule.Pipeline;
+using PSRule.Resources;
 using PSRule.Runtime;
 using System.Management.Automation;
 using System.Text.RegularExpressions;
@@ -63,12 +64,12 @@ namespace PSRule.Commands
                     if (_Expressions[i].IsMatch(fieldValue.ToString()))
                     {
                         match = true;
+                        PipelineContext.CurrentThread.VerboseConditionMessage(condition: RuleLanguageNouns.Match, message: PSRuleResources.MatchTrue, args: fieldValue);
                     }
                 }
             }
 
             var result = expected == match;
-
             PipelineContext.CurrentThread.VerboseConditionResult(condition: RuleLanguageNouns.Match, outcome: result);
             WriteObject(result);
         }

--- a/src/PSRule/Commands/InvokeRuleBlockCommand.cs
+++ b/src/PSRule/Commands/InvokeRuleBlockCommand.cs
@@ -34,6 +34,7 @@ namespace PSRule.Commands
 
                 if (!Type.Contains(value: PipelineContext.CurrentThread.TargetType, comparer: comparer))
                 {
+                    PipelineContext.CurrentThread.Logger.DebugMessage("Target failed Type precondition");
                     return;
                 }
             }
@@ -45,6 +46,7 @@ namespace PSRule.Commands
 
                 if (ifResult == null || !(ifResult.BaseObject is bool) || !(bool)ifResult.BaseObject)
                 {
+                    PipelineContext.CurrentThread.Logger.DebugMessage("Target failed If precondition");
                     return;
                 }
             }

--- a/src/PSRule/Configuration/LoggingOption.cs
+++ b/src/PSRule/Configuration/LoggingOption.cs
@@ -13,20 +13,38 @@ namespace PSRule.Configuration
         public static readonly LoggingOption Default = new LoggingOption
         {
             RuleFail = DEFAULT_RULEFAIL,
-            RulePass = DEFAULT_RULEPASS
+            RulePass = DEFAULT_RULEPASS,
+            LimitVerbose = null,
+            LimitDebug = null
         };
 
         public LoggingOption()
         {
+            LimitDebug = null;
+            LimitVerbose = null;
             RuleFail = null;
             RulePass = null;
         }
 
         public LoggingOption(LoggingOption option)
         {
+            LimitDebug = option.LimitDebug;
+            LimitVerbose = option.LimitVerbose;
             RuleFail = option.RuleFail;
             RulePass = option.RulePass;
         }
+
+        /// <summary>
+        /// Limits debug messages to a list of named debug scopes.
+        /// </summary>
+        [DefaultValue(null)]
+        public string[] LimitDebug { get; set; }
+
+        /// <summary>
+        /// Limits verbose messages to a list of named verbose scopes.
+        /// </summary>
+        [DefaultValue(null)]
+        public string[] LimitVerbose { get; set; }        
 
         /// <summary>
         /// Log fail outcomes for each rule to a specific informational stream.

--- a/src/PSRule/Configuration/PSRuleOption.cs
+++ b/src/PSRule/Configuration/PSRuleOption.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using PSRule.Resources;
 using System;
 using System.Collections;
@@ -320,6 +320,30 @@ namespace PSRule.Configuration
             if (index.TryGetValue("input.objectpath", out value))
             {
                 option.Input.ObjectPath = (string)value;
+            }
+
+            if (index.TryGetValue("logging.limitdebug", out value))
+            {
+                if (value.GetType().IsArray)
+                {
+                    option.Logging.LimitDebug = ((object[])value).OfType<string>().ToArray();
+                }
+                else
+                {
+                    option.Logging.LimitDebug = new string[] { value.ToString() };
+                }
+            }
+
+            if (index.TryGetValue("logging.limitverbose", out value))
+            {
+                if (value.GetType().IsArray)
+                {
+                    option.Logging.LimitVerbose = ((object[])value).OfType<string>().ToArray();
+                }
+                else
+                {
+                    option.Logging.LimitVerbose = new string[] { value.ToString() };
+                }
             }
 
             if (index.TryGetValue("logging.rulefail", out value))

--- a/src/PSRule/Host/HostHelper.cs
+++ b/src/PSRule/Host/HostHelper.cs
@@ -97,6 +97,7 @@ namespace PSRule.Host
             {
                 ps.Runspace = runspace;
                 PipelineContext.EnableLogging(ps);
+                PipelineContext.CurrentThread.Logger.EnterScope("[Discovery.Rule]");
 
                 // Process scripts
 
@@ -140,6 +141,7 @@ namespace PSRule.Host
             }
             finally
             {
+                PipelineContext.CurrentThread.Logger.ExitScope();
                 PipelineContext.CurrentThread.Source = null;
                 ps.Runspace = null;
                 ps.Dispose();

--- a/src/PSRule/Pipeline/GetRuleHelpPipelineBuilder.cs
+++ b/src/PSRule/Pipeline/GetRuleHelpPipelineBuilder.cs
@@ -10,10 +10,6 @@ namespace PSRule.Pipeline
         private readonly PipelineLogger _Logger;
 
         private RuleSource[] _Source;
-        private bool _LogError;
-        private bool _LogWarning;
-        private bool _LogVerbose;
-        private bool _LogInformation;
 
         internal GetRuleHelpPipelineBuilder()
         {
@@ -41,29 +37,24 @@ namespace PSRule.Pipeline
                 _Option.Baseline.Exclude = option.Baseline.Exclude;
             }
 
+            _Logger.Configure(_Option);
             return this;
         }
 
         public void UseCommandRuntime(ICommandRuntime2 commandRuntime)
         {
-            _Logger.OnWriteVerbose = commandRuntime.WriteVerbose;
-            _Logger.OnWriteWarning = commandRuntime.WriteWarning;
-            _Logger.OnWriteError = commandRuntime.WriteError;
-            _Logger.OnWriteInformation = commandRuntime.WriteInformation;
+            _Logger.UseCommandRuntime(commandRuntime);
         }
 
-        public void UseLoggingPreferences(ActionPreference error, ActionPreference warning, ActionPreference verbose, ActionPreference information)
+        public void UseExecutionContext(EngineIntrinsics executionContext)
         {
-            _LogError = (error != ActionPreference.Ignore);
-            _LogWarning = (warning != ActionPreference.Ignore);
-            _LogVerbose = !(verbose == ActionPreference.Ignore || verbose == ActionPreference.SilentlyContinue);
-            _LogInformation = !(information == ActionPreference.Ignore || information == ActionPreference.SilentlyContinue);
+            _Logger.UseExecutionContext(executionContext);
         }
 
         public GetRuleHelpPipeline Build()
         {
             var filter = new RuleFilter(ruleName: _Option.Baseline.RuleName, tag: null, exclude: _Option.Baseline.Exclude, wildcardMatch: true);
-            var context = PipelineContext.New(logger: _Logger, option: _Option, bindTargetName: null, bindTargetType: null, logError: _LogError, logWarning: _LogWarning, logVerbose: _LogVerbose, logInformation: _LogInformation);
+            var context = PipelineContext.New(logger: _Logger, option: _Option, bindTargetName: null, bindTargetType: null);
             return new GetRuleHelpPipeline(option: _Option, source: _Source, filter: filter, context: context);
         }
     }

--- a/src/PSRule/Pipeline/ILogger.cs
+++ b/src/PSRule/Pipeline/ILogger.cs
@@ -10,10 +10,26 @@ namespace PSRule.Pipeline
     {
         void WriteVerbose(string message);
 
+        bool ShouldWriteVerbose();
+
         void WriteWarning(string message);
+
+        bool ShouldWriteWarning();
 
         void WriteError(ErrorRecord errorRecord);
 
+        bool ShouldWriteError();
+
         void WriteInformation(InformationRecord informationRecord);
+
+        bool ShouldWriteInformation();
+
+        void WriteDebug(DebugRecord debugRecord);
+
+        bool ShouldWriteDebug();
+
+        void EnterScope(string scopeName);
+
+        void ExitScope();
     }
 }

--- a/src/PSRule/Pipeline/ILoggerExtensions.cs
+++ b/src/PSRule/Pipeline/ILoggerExtensions.cs
@@ -1,0 +1,17 @@
+﻿using System.Management.Automation;
+
+namespace PSRule.Pipeline
+{
+    internal static class ILoggerExtensions
+    {
+        public static void DebugMessage(this ILogger logger, string message)
+        {
+            if (!logger.ShouldWriteDebug())
+            {
+                return;
+            }
+
+            logger.WriteDebug(new DebugRecord(message));
+        }
+    }
+}

--- a/src/PSRule/Pipeline/PipelineBuilder.cs
+++ b/src/PSRule/Pipeline/PipelineBuilder.cs
@@ -1,4 +1,6 @@
-﻿namespace PSRule.Pipeline
+﻿using PSRule.Rules;
+
+namespace PSRule.Pipeline
 {
     public static class PipelineBuilder
     {
@@ -15,6 +17,11 @@
         public static GetRuleHelpPipelineBuilder GetHelp()
         {
             return new GetRuleHelpPipelineBuilder();
+        }
+
+        public static RuleSourceBuilder RuleSource()
+        {
+            return new RuleSourceBuilder();
         }
     }
 }

--- a/src/PSRule/Pipeline/PipelineContext.cs
+++ b/src/PSRule/Pipeline/PipelineContext.cs
@@ -254,14 +254,14 @@ namespace PSRule.Pipeline
             _Logger.WriteVerbose(string.Concat(GetLogPrefix(), " :: ", TargetName));
         }
 
-        public void VerboseConditionMessage(string condition, string message)
+        public void VerboseConditionMessage(string condition, string message, params object[] args)
         {
             if (!_Logger.ShouldWriteVerbose())
             {
                 return;
             }
 
-            _Logger.WriteVerbose(string.Concat(GetLogPrefix(), "[", condition, "] -- ", message));
+            _Logger.WriteVerbose(string.Concat(GetLogPrefix(), "[", condition, "] -- ", string.Format(message, args)));
         }
 
         public void VerboseConditionResult(string condition, int pass, int count, bool outcome)

--- a/src/PSRule/Pipeline/PipelineLogger.cs
+++ b/src/PSRule/Pipeline/PipelineLogger.cs
@@ -1,55 +1,101 @@
-﻿using System;
+﻿using PSRule.Configuration;
+using PSRule.Resources;
+using PSRule.Rules;
+using System;
+using System.Collections.Generic;
 using System.Management.Automation;
 
 namespace PSRule.Pipeline
 {
     internal sealed class PipelineLogger : ILogger
     {
-        internal Action<string> OnWriteWarning;
-        internal Action<string> OnWriteVerbose;
-        internal Action<ErrorRecord> OnWriteError;
-        internal Action<InformationRecord> OnWriteInformation;
+        private const string ErrorPreference = "ErrorActionPreference";
+        private const string WarningPreference = "WarningPreference";
+        private const string VerbosePreference = "VerbosePreference";
+        private const string InformationPreference = "InformationPreference";
+        private const string DebugPreference = "DebugPreference";
+
+        private HashSet<string> _VerboseFilter;
+        private HashSet<string> _DebugFilter;
+
+        private Action<string> OnWriteWarning;
+        private Action<string> OnWriteVerbose;
+        private Action<ErrorRecord> OnWriteError;
+        private Action<InformationRecord> OnWriteInformation;
+        private Action<string> OnWriteDebug;
         internal Action<object, bool> OnWriteObject;
+
+        private string _ScopeName;
+
+        private bool _LogError;
+        private bool _LogWarning;
+        private bool _LogVerbose;
+        private bool _LogInformation;
+        private bool _LogDebug;
+
+        #region Logging
 
         public void WriteError(ErrorRecord errorRecord)
         {
-            if (OnWriteError == null)
+            if (!ShouldWriteError() || errorRecord == null)
             {
                 return;
             }
 
-            OnWriteError(errorRecord);
+            DoWriteError(errorRecord);
         }
 
         public void WriteVerbose(string message)
         {
-            if (OnWriteVerbose == null)
+            if (!ShouldWriteVerbose() || string.IsNullOrEmpty(message))
             {
                 return;
             }
 
-            OnWriteVerbose(message);
+            DoWriteVerbose(message);
         }
 
-        public void WriteWarning(string message)
+        public void WriteDebug(DebugRecord debugRecord)
         {
-            if (OnWriteWarning == null)
+            if (!ShouldWriteDebug())
             {
                 return;
             }
 
-            OnWriteWarning(message);
+            DoWriteDebug(debugRecord);
         }
 
         public void WriteInformation(InformationRecord informationRecord)
         {
-            if (OnWriteInformation == null)
+            if (!ShouldWriteInformation())
             {
                 return;
             }
 
-            OnWriteInformation(informationRecord);
+            DoWriteInformation(informationRecord);
         }
+
+        public void WriteWarning(string message)
+        {
+            if (!ShouldWriteWarning())
+            {
+                return;
+            }
+
+            DoWriteWarning(message);
+        }
+
+        public void EnterScope(string scopeName)
+        {
+            _ScopeName = scopeName;
+        }
+
+        public void ExitScope()
+        {
+            _ScopeName = null;
+        }
+
+        #endregion Logging
 
         public void WriteObject(object sendToPipeline, bool enumerateCollection)
         {
@@ -59,6 +105,147 @@ namespace PSRule.Pipeline
             }
 
             OnWriteObject(sendToPipeline, enumerateCollection);
+        }
+
+        internal void UseCommandRuntime(ICommandRuntime2 commandRuntime)
+        {
+            OnWriteVerbose = commandRuntime.WriteVerbose;
+            OnWriteWarning = commandRuntime.WriteWarning;
+            OnWriteError = commandRuntime.WriteError;
+            OnWriteInformation = commandRuntime.WriteInformation;
+            OnWriteDebug = commandRuntime.WriteDebug;
+            OnWriteObject = commandRuntime.WriteObject;
+        }
+
+        internal void UseExecutionContext(EngineIntrinsics executionContext)
+        {
+            _LogError = GetPreferenceVariable(executionContext, ErrorPreference);
+            _LogWarning = GetPreferenceVariable(executionContext, WarningPreference);
+            _LogVerbose = GetPreferenceVariable(executionContext, VerbosePreference);
+            _LogInformation = GetPreferenceVariable(executionContext, InformationPreference);
+            _LogDebug = GetPreferenceVariable(executionContext, DebugPreference);
+        }
+
+        internal void Configure(PSRuleOption option)
+        {
+            if (option.Logging.LimitVerbose != null && option.Logging.LimitVerbose.Length > 0)
+            {
+                _VerboseFilter = new HashSet<string>(option.Logging.LimitVerbose);
+            }
+
+            if (option.Logging.LimitDebug != null && option.Logging.LimitDebug.Length > 0)
+            {
+                _DebugFilter = new HashSet<string>(option.Logging.LimitDebug);
+            }
+        }
+
+        private bool GetPreferenceVariable(EngineIntrinsics executionContext, string variableName)
+        {
+            var preference = (ActionPreference)executionContext.SessionState.PSVariable.GetValue(variableName);
+
+            if (preference == ActionPreference.Ignore)
+            {
+                return false;
+            }
+
+            return !(preference == ActionPreference.SilentlyContinue && (variableName == VerbosePreference || variableName == DebugPreference));
+        }
+
+        #region Internal logging methods
+
+        /// <summary>
+        /// Core methods to hand off to logger.
+        /// </summary>
+        /// <param name="errorRecord">A valid PowerShell error record.</param>
+        private void DoWriteError(ErrorRecord errorRecord)
+        {
+            if (OnWriteError == null)
+            {
+                return;
+            }
+
+            OnWriteError(errorRecord);
+        }
+
+        /// <summary>
+        /// Core method to hand off verbose messages to logger.
+        /// </summary>
+        /// <param name="message">A message to log.</param>
+        private void DoWriteVerbose(string message)
+        {
+            if (OnWriteVerbose == null)
+            {
+                return;
+            }
+
+            OnWriteVerbose(message);
+        }
+
+        /// <summary>
+        /// Core method to hand off warning messages to logger.
+        /// </summary>
+        /// <param name="message">A message to log</param>
+        private void DoWriteWarning(string message)
+        {
+            if (OnWriteWarning == null)
+            {
+                return;
+            }
+
+            OnWriteWarning(message);
+        }
+
+        /// <summary>
+        /// Core method to hand off information messages to logger.
+        /// </summary>
+        private void DoWriteInformation(InformationRecord informationRecord)
+        {
+            if (OnWriteInformation == null)
+            {
+                return;
+            }
+
+            OnWriteInformation(informationRecord);
+        }
+
+        /// <summary>
+        /// Core method to hand off debug messages to logger.
+        /// </summary>
+        private void DoWriteDebug(DebugRecord debugRecord)
+        {
+            if (OnWriteDebug == null)
+            {
+                return;
+            }
+
+            OnWriteDebug(debugRecord.Message);
+        }
+
+        #endregion Internal logging methods
+
+        public bool ShouldWriteError()
+        {
+            return true;
+        }
+
+        public bool ShouldWriteWarning()
+        {
+            return true;
+        }
+
+        public bool ShouldWriteVerbose()
+        {
+            return _LogVerbose && (_VerboseFilter == null || _ScopeName == null || _VerboseFilter.Contains(_ScopeName));
+        }
+
+        public bool ShouldWriteInformation()
+        {
+            return true;
+        }
+
+        public bool ShouldWriteDebug()
+        {
+            return _LogDebug && (_DebugFilter == null || _ScopeName == null || _DebugFilter.Contains(_ScopeName));
         }
     }
 }

--- a/src/PSRule/Resources/PSRuleResources.Designer.cs
+++ b/src/PSRule/Resources/PSRuleResources.Designer.cs
@@ -88,6 +88,15 @@ namespace PSRule.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Exists: {0}.
+        /// </summary>
+        internal static string ExistsTrue {
+            get {
+                return ResourceManager.GetString("ExistsTrue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to [PSRule][D] -- Found {0} PSRule module(s).
         /// </summary>
         internal static string FoundModules {
@@ -111,6 +120,15 @@ namespace PSRule.Resources {
         internal static string InvalidRuleResult {
             get {
                 return ResourceManager.GetString("InvalidRuleResult", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Matches: {0}.
+        /// </summary>
+        internal static string MatchTrue {
+            get {
+                return ResourceManager.GetString("MatchTrue", resourceCulture);
             }
         }
         
@@ -228,6 +246,15 @@ namespace PSRule.Resources {
         internal static string ShouldWriteFile {
             get {
                 return ResourceManager.GetString("ShouldWriteFile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Within: {0}.
+        /// </summary>
+        internal static string WithinTrue {
+            get {
+                return ResourceManager.GetString("WithinTrue", resourceCulture);
             }
         }
     }

--- a/src/PSRule/Resources/PSRuleResources.Designer.cs
+++ b/src/PSRule/Resources/PSRuleResources.Designer.cs
@@ -88,6 +88,15 @@ namespace PSRule.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to [PSRule][D] -- Found {0} PSRule module(s).
+        /// </summary>
+        internal static string FoundModules {
+            get {
+                return ResourceManager.GetString("FoundModules", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Rule nesting was detected in rule &apos;{0}&apos;. Rules must not be nested..
         /// </summary>
         internal static string InvalidRuleNesting {
@@ -165,6 +174,24 @@ namespace PSRule.Resources {
         internal static string RuleNotFound {
             get {
                 return ResourceManager.GetString("RuleNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to [PSRule][D] -- Scanning for source files in module: {0}.
+        /// </summary>
+        internal static string ScanModule {
+            get {
+                return ResourceManager.GetString("ScanModule", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to [PSRule][D] -- Scanning for source files: {0}.
+        /// </summary>
+        internal static string ScanSource {
+            get {
+                return ResourceManager.GetString("ScanSource", resourceCulture);
             }
         }
         

--- a/src/PSRule/Resources/PSRuleResources.resx
+++ b/src/PSRule/Resources/PSRuleResources.resx
@@ -129,6 +129,9 @@
     <value>A rule with the same name '{0}' already exists.</value>
     <comment>Occurs when the same rule name is used.</comment>
   </data>
+  <data name="FoundModules" xml:space="preserve">
+    <value>[PSRule][D] -- Found {0} PSRule module(s)</value>
+  </data>
   <data name="InvalidRuleNesting" xml:space="preserve">
     <value>Rule nesting was detected in rule '{0}'. Rules must not be nested.</value>
     <comment>Occurs when a rule is nested in another rule.</comment>
@@ -157,6 +160,12 @@
   </data>
   <data name="RuleNotFound" xml:space="preserve">
     <value>Could not find a matching rule. Please check that Path, Name and Tag parameters are correct.</value>
+  </data>
+  <data name="ScanModule" xml:space="preserve">
+    <value>[PSRule][D] -- Scanning for source files in module: {0}</value>
+  </data>
+  <data name="ScanSource" xml:space="preserve">
+    <value>[PSRule][D] -- Scanning for source files: {0}</value>
   </data>
   <data name="ScriptNotFound" xml:space="preserve">
     <value>The script was not found.</value>

--- a/src/PSRule/Resources/PSRuleResources.resx
+++ b/src/PSRule/Resources/PSRuleResources.resx
@@ -129,6 +129,9 @@
     <value>A rule with the same name '{0}' already exists.</value>
     <comment>Occurs when the same rule name is used.</comment>
   </data>
+  <data name="ExistsTrue" xml:space="preserve">
+    <value>Exists: {0}</value>
+  </data>
   <data name="FoundModules" xml:space="preserve">
     <value>[PSRule][D] -- Found {0} PSRule module(s)</value>
   </data>
@@ -138,6 +141,9 @@
   </data>
   <data name="InvalidRuleResult" xml:space="preserve">
     <value>An invalid rule result was returned for {0}. Conditions must return boolean $True or $False.</value>
+  </data>
+  <data name="MatchTrue" xml:space="preserve">
+    <value>Matches: {0}</value>
   </data>
   <data name="ObjectNotProcessed" xml:space="preserve">
     <value>Target object '{0}' has not been processed because no matching rules were found.</value>
@@ -179,5 +185,8 @@
   </data>
   <data name="ShouldWriteFile" xml:space="preserve">
     <value>Write file</value>
+  </data>
+  <data name="WithinTrue" xml:space="preserve">
+    <value>Within: {0}</value>
   </data>
 </root>

--- a/src/PSRule/Rules/RuleSource.cs
+++ b/src/PSRule/Rules/RuleSource.cs
@@ -1,4 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using PSRule.Configuration;
+using PSRule.Pipeline;
+using PSRule.Resources;
+using System.Collections.Generic;
+using System.Management.Automation;
 
 namespace PSRule.Rules
 {
@@ -25,10 +29,56 @@ namespace PSRule.Rules
     public sealed class RuleSourceBuilder
     {
         private readonly List<RuleSource> _Source;
+        private readonly PipelineLogger _Logger;
 
-        public RuleSourceBuilder()
+        internal RuleSourceBuilder()
         {
             _Source = new List<RuleSource>();
+            _Logger = new PipelineLogger();
+        }
+
+        public RuleSourceBuilder Configure(PSRuleOption option)
+        {
+            _Logger.Configure(option);
+            _Logger.EnterScope("[Discovery.Source]");
+            return this;
+        }
+
+        public void UseCommandRuntime(ICommandRuntime2 commandRuntime)
+        {
+            _Logger.UseCommandRuntime(commandRuntime);
+        }
+
+        public void UseExecutionContext(EngineIntrinsics executionContext)
+        {
+            _Logger.UseExecutionContext(executionContext);
+        }
+
+        public void VerboseScanSource(string path)
+        {
+            if (!_Logger.ShouldWriteVerbose())
+            {
+                return;
+            }
+            _Logger.WriteVerbose(string.Format(PSRuleResources.ScanSource, path));
+        }
+
+        public void VerboseFoundModules(int count)
+        {
+            if (!_Logger.ShouldWriteVerbose())
+            {
+                return;
+            }
+            _Logger.WriteVerbose(string.Format(PSRuleResources.FoundModules, count));
+        }
+
+        public void VerboseScanModule(string moduleName)
+        {
+            if (!_Logger.ShouldWriteVerbose())
+            {
+                return;
+            }
+            _Logger.WriteVerbose(string.Format(PSRuleResources.ScanModule, moduleName));
         }
 
         public void Add(string path, string moduleName, string helpPath)
@@ -37,7 +87,6 @@ namespace PSRule.Rules
             {
                 return;
             }
-
             _Source.Add(new RuleSource(path, moduleName, new string[] { helpPath }));
         }
 
@@ -47,7 +96,6 @@ namespace PSRule.Rules
             {
                 return;
             }
-
             _Source.Add(new RuleSource(path, null, new string[] { helpPath }));
         }
 

--- a/tests/PSRule.Tests/FromFile.Rule.ps1
+++ b/tests/PSRule.Tests/FromFile.Rule.ps1
@@ -222,6 +222,7 @@ Rule 'WithinNot' {
 Rule 'WithinTypes' {
     Within 'BooleanValue' $True
     Within 'IntValue' 0, 1, 2, 3
+    Within 'NullValue' $Null
 }
 
 # Synopsis: Test for Match keyword

--- a/tests/PSRule.Tests/FromFileWithLogging.Rule.ps1
+++ b/tests/PSRule.Tests/FromFileWithLogging.Rule.ps1
@@ -3,6 +3,7 @@
 #
 
 # Logging in main script
+Write-Debug -Message 'Script debug message';
 Write-Information -MessageData 'Script information message';
 Write-Verbose -Message 'Script verbose message';
 Write-Warning -Message 'Script warning message';
@@ -22,7 +23,22 @@ Rule 'WithVerbose' {
     $True;
 }
 
+Rule 'WithVerbose2' {
+    Write-Verbose -Message 'Rule verbose message 2';
+    $True;
+}
+
 Rule 'WithInformation' {
     Write-Information -MessageData 'Rule information message';
+    $True;
+}
+
+Rule 'WithDebug' {
+    Write-Debug -Message 'Rule debug message';
+    $True;
+}
+
+Rule 'WithDebug2' {
+    Write-Debug -Message 'Rule debug message 2';
     $True;
 }

--- a/tests/PSRule.Tests/PSRule.Common.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Common.Tests.ps1
@@ -752,6 +752,58 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
             $messages | Should -Not -BeNullOrEmpty;
             $messages | Should -Be "[PASS] -- FromFile1:: Reported for 'LoggingTest'"
         }
+
+        It 'LimitDebug' {
+            $withLoggingRulePath = (Join-Path -Path $here -ChildPath 'FromFileWithLogging.Rule.ps1');
+            $loggingParams = @{
+                Path = $withLoggingRulePath
+                Name = 'WithDebug', 'WithDebug2'
+                WarningAction = 'SilentlyContinue'
+                ErrorAction = 'SilentlyContinue'
+                InformationAction = 'SilentlyContinue'
+            }
+            $option = New-PSRuleOption -LoggingLimitDebug 'WithDebug2', '[Discovery.Rule]';
+
+            $testObject = [PSCustomObject]@{
+                Name = 'LoggingTest'
+            }
+
+            $DebugPreference = 'Continue';
+            $outDebug = @($testObject | Invoke-PSRule @loggingParams -Option $option -Debug 5>&1 | Where-Object {
+                $_ -like "* debug message*"
+            });
+
+            # Debug
+            $outDebug.Length | Should -Be 2;
+            $outDebug[0] | Should -Be 'Script debug message';
+            $outDebug[1] | Should -Be 'Rule debug message 2';
+        }
+
+        It 'LimitVerbose' {
+            $withLoggingRulePath = (Join-Path -Path $here -ChildPath 'FromFileWithLogging.Rule.ps1');
+            $loggingParams = @{
+                Path = $withLoggingRulePath
+                Name = 'WithVerbose', 'WithVerbose2'
+                WarningAction = 'SilentlyContinue'
+                ErrorAction = 'SilentlyContinue'
+                InformationAction = 'SilentlyContinue'
+            }
+            $option = New-PSRuleOption -LoggingLimitVerbose 'WithVerbose2', '[Discovery.Rule]';
+
+            $testObject = [PSCustomObject]@{
+                Name = 'LoggingTest'
+            }
+
+            $outVerbose = @($testObject | Invoke-PSRule @loggingParams -Option $option -Verbose 4>&1 | Where-Object {
+                $_ -is [System.Management.Automation.VerboseRecord] -and
+                $_.Message -like "* verbose message*"
+            });
+
+            # Verbose
+            $outVerbose.Length | Should -Be 2;
+            $outVerbose[0] | Should -Be 'Script verbose message';
+            $outVerbose[1] | Should -Be 'Rule verbose message 2';
+        }
     }
 }
 

--- a/tests/PSRule.Tests/PSRule.Common.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Common.Tests.ps1
@@ -768,10 +768,18 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
                 Name = 'LoggingTest'
             }
 
-            $DebugPreference = 'Continue';
-            $outDebug = @($testObject | Invoke-PSRule @loggingParams -Option $option -Debug 5>&1 | Where-Object {
-                $_ -like "* debug message*"
-            });
+            $outDebug = @()
+            $originalDebugPreference = $DebugPreference;
+
+            try {
+                $Global:DebugPreference = [System.Management.Automation.ActionPreference]::Continue;
+                $outDebug += ($testObject | Invoke-PSRule @loggingParams -Option $option 5>&1 | Where-Object {
+                    $_ -like "* debug message*"
+                });
+            }
+            finally {
+                $Global:DebugPreference = $originalDebugPreference;
+            }
 
             # Debug
             $outDebug.Length | Should -Be 2;

--- a/tests/PSRule.Tests/PSRule.Options.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Options.Tests.ps1
@@ -338,6 +338,50 @@ Describe 'New-PSRuleOption' -Tag 'Option','New-PSRuleOption' {
         }
     }
 
+    Context 'Read Logging.LimitDebug' {
+        It 'from default' {
+            $option = New-PSRuleOption;
+            $option.Logging.LimitDebug | Should -BeNullOrEmpty;
+        }
+
+        It 'from Hashtable' {
+            $option = New-PSRuleOption -Option @{ 'Logging.LimitDebug' = 'TestRule1' };
+            $option.Logging.LimitDebug | Should -Be 'TestRule1';
+        }
+
+        It 'from YAML' {
+            $option = New-PSRuleOption -Option (Join-Path -Path $here -ChildPath 'PSRule.Tests.yml');
+            $option.Logging.LimitDebug | Should -Be 'TestRule2';
+        }
+
+        It 'from parameter' {
+            $option = New-PSRuleOption -LoggingLimitDebug 'TestRule2' -Path $emptyOptionsFilePath;
+            $option.Logging.LimitDebug | Should -Be 'TestRule2';
+        }
+    }
+
+    Context 'Read Logging.LimitVerbose' {
+        It 'from default' {
+            $option = New-PSRuleOption;
+            $option.Logging.LimitVerbose | Should -BeNullOrEmpty;
+        }
+
+        It 'from Hashtable' {
+            $option = New-PSRuleOption -Option @{ 'Logging.LimitVerbose' = 'TestRule1' };
+            $option.Logging.LimitVerbose | Should -Be 'TestRule1';
+        }
+
+        It 'from YAML' {
+            $option = New-PSRuleOption -Option (Join-Path -Path $here -ChildPath 'PSRule.Tests.yml');
+            $option.Logging.LimitVerbose | Should -Be 'TestRule2';
+        }
+
+        It 'from parameter' {
+            $option = New-PSRuleOption -LoggingLimitVerbose 'TestRule2' -Path $emptyOptionsFilePath;
+            $option.Logging.LimitVerbose | Should -Be 'TestRule2';
+        }
+    }
+
     Context 'Read Logging.RuleFail' {
         It 'from default' {
             $option = New-PSRuleOption;
@@ -613,6 +657,20 @@ Describe 'Set-PSRuleOption' -Tag 'Option','Set-PSRuleOption' {
         It 'from parameter' {
             $option = Set-PSRuleOption -ObjectPath 'items' @optionParams;
             $option.Input.ObjectPath | Should -Be 'items';
+        }
+    }
+
+    Context 'Read Logging.LimitDebug' {
+        It 'from parameter' {
+            $option = Set-PSRuleOption -LoggingLimitDebug 'TestRule2' @optionParams;
+            $option.Logging.LimitDebug | Should -Be 'TestRule2';
+        }
+    }
+
+    Context 'Read Logging.LimitVerbose' {
+        It 'from parameter' {
+            $option = Set-PSRuleOption -LoggingLimitVerbose 'TestRule2' @optionParams;
+            $option.Logging.LimitVerbose | Should -Be 'TestRule2';
         }
     }
 

--- a/tests/PSRule.Tests/PSRule.Tests.yml
+++ b/tests/PSRule.Tests/PSRule.Tests.yml
@@ -37,7 +37,7 @@ logging:
   limitVerbose:
   - TestRule2
   ruleFail: Warning
-  rulePass: Warning  
+  rulePass: Warning
 
 # Configure output options
 output:

--- a/tests/PSRule.Tests/PSRule.Tests.yml
+++ b/tests/PSRule.Tests/PSRule.Tests.yml
@@ -32,8 +32,12 @@ input:
 
 # Configures outcome logging options
 logging:
+  limitDebug:
+  - TestRule2
+  limitVerbose:
+  - TestRule2
   ruleFail: Warning
-  rulePass: Warning
+  rulePass: Warning  
 
 # Configure output options
 output:

--- a/tests/PSRule.Tests/PSRule.Within.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Within.Tests.ps1
@@ -42,16 +42,20 @@ Describe 'PSRule -- Within keyword' -Tag 'Within' {
 
             # Check non-string types
             $testObject = @(
-                [PSCustomObject]@{ BooleanValue = $True; IntValue = 1 }
-                [PSCustomObject]@{ BooleanValue = $False; IntValue = 100 }
+                [PSCustomObject]@{ BooleanValue = $True; IntValue = 1; NullValue = $Null; }
+                [PSCustomObject]@{ BooleanValue = $False; IntValue = 100; NullValue = $Null; }
+                ([PSCustomObject]@{ BooleanValue = $True; IntValue = 1; NullValue = $Null; } | ConvertTo-Json | ConvertFrom-Json)
+                [PSCustomObject]@{ BooleanValue = $Null; IntValue = $Null; NullValue = 'NotNull'; }
             )
 
             $result = $testObject | Invoke-PSRule -Path $ruleFilePath -Name 'WithinTypes' -Outcome All;
             $result | Should -Not -BeNullOrEmpty;
-            $result.Count | Should -Be 2;
+            $result.Count | Should -Be 4;
             $result.RuleName | Should -BeIn 'WithinTypes';
             $result[0].IsSuccess() | Should -Be $True;
             $result[1].IsSuccess() | Should -Be $False;
+            $result[2].IsSuccess() | Should -Be $True;
+            $result[3].IsSuccess() | Should -Be $False;
         }
 
         It 'With -CaseSensitive' {


### PR DESCRIPTION
## PR Summary

- Fix comparison of wrapped types and null with `Within`. #237
- Add support for debug messages and `Write-Debug` in rule definitions. #146
- Added `Logging.LimitDebug` and `Logging.LimitVerbose` options to limit logging to named scopes. #235

Fixes #235 
Fixes #237 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/BernieWhite/PSRule/blob/master/CHANGELOG.md) has been updated with change under unreleased section
