### PR TITLE
Pre-release v0.8.0-B190716

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 
 ## Unreleased
 
+## v0.8.0-B190716 (pre-release)
+
 - Added per object reason for failing rules. [#200](https://github.com/BernieWhite/PSRule/issues/200)
   - The keywords `Exists`, `Match`, `Within` and `TypeOf` automatically add a reason when they fail.
   - Added `-Reason` parameter to `Exists`, `Match`, `Within` and `TypeOf` keywords to allow a custom reason to be set.

--- a/docs/keywords/PSRule/en-US/about_PSRule_Keywords.md
+++ b/docs/keywords/PSRule/en-US/about_PSRule_Keywords.md
@@ -375,6 +375,7 @@ An online version of this document is available at https://github.com/BernieWhit
 - AllOf
 - Within
 - TypeOf
+- Reason
 - Recommend
 
 [Invoke-PSRule]: https://github.com/BernieWhite/PSRule/blob/master/docs/commands/PSRule/en-US/Invoke-PSRule.md


### PR DESCRIPTION
## PR Summary

- Added per object reason for failing rules. #200
  - The keywords `Exists`, `Match`, `Within` and `TypeOf` automatically add a reason when they fail.
  - Added `-Reason` parameter to `Exists`, `Match`, `Within` and `TypeOf` keywords to allow a custom reason to be set.
  - Added `Reason` keyword to add to reason for custom logic.
  - Added wide output display for `Invoke-PSRule` which include the reason why rule failed.
    - To use wide output use the `-OutputFormat Wide` parameter.
  - Renamed `-Message` parameter to `-Text` on the `Recommend` keyword.
    - The `-Message` is an alias of `-Text` and will be deprecated in the future.
## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
