### PR TITLE
Add assertion helper and fix $PWD #249 #250 #42

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 
 ## Unreleased
 
+- Fix inconsistent handling of `$PWD`. [#249](https://github.com/BernieWhite/PSRule/issues/249)
 - Add detection for improper keyword use. [#203](https://github.com/BernieWhite/PSRule/issues/203)
 - Automatically load rule modules. [#218](https://github.com/BernieWhite/PSRule/issues/218)
+- Added assertion helper `$Assert` for extensibility. [#250](https://github.com/BernieWhite/PSRule/issues/250)
+  - Add built-in assertions for `HasField`, `HasFieldValue` and `NullOrEmpty`.
+  - Add JSON schema assertion method `JsonSchema`. [#42](https://github.com/BernieWhite/PSRule/issues/42)
 - **Breaking change**: Use rule references consistent with cmdlet fully qualified syntax. [#217](https://github.com/BernieWhite/PSRule/issues/217)
   - Previously rule names only had to be unique within a single file, now rule names have to be unique within the current execution path or within a module.
   - Previously the `filename.rule.ps1/RuleName` was supported to reference rules across files. Because rule names must be unique this syntax is no longer required or supported.

--- a/README.md
+++ b/README.md
@@ -188,6 +188,11 @@ The following commands exist in the `PSRule` module:
 
 The following conceptual topics exist in the `PSRule` module:
 
+- [Assert](docs/concepts/PSRule/en-US/about_PSRule_Assert.md)
+  - [HasField](docs/concepts/PSRule/en-US/about_PSRule_Assert.md#hasfield)
+  - [HasFieldValue](docs/concepts/PSRule/en-US/about_PSRule_Assert.md#hasfieldvalue)
+  - [JsonSchema](docs/concepts/PSRule/en-US/about_PSRule_Assert.md#jsonschema)
+  - [NullOrEmpty](docs/concepts/PSRule/en-US/about_PSRule_Assert.md#nullorempty)
 - [Docs](docs/concepts/PSRule/en-US/about_PSRule_Docs.md)
   - [Getting documentation](docs/concepts/PSRule/en-US/about_PSRule_Docs.md#getting-documentation)
   - [Online help](docs/concepts/PSRule/en-US/about_PSRule_Docs.md#online-help)
@@ -214,6 +219,7 @@ The following conceptual topics exist in the `PSRule` module:
   - [Output.Path](docs/concepts/PSRule/en-US/about_PSRule_Options.md#outputpath)
   - [Suppression](docs/concepts/PSRule/en-US/about_PSRule_Options.md#rule-suppression)
 - [Variables](docs/concepts/PSRule/en-US/about_PSRule_Variables.md)
+  - [$Assert](docs/concepts/PSRule/en-US/about_PSRule_Variables.md#assert)
   - [$Configuration](docs/concepts/PSRule/en-US/about_PSRule_Variables.md#configuration)
   - [$LocalizedData](docs/concepts/PSRule/en-US/about_PSRule_Variables.md#localizeddata)
   - [$Rule](docs/concepts/PSRule/en-US/about_PSRule_Variables.md#rule)

--- a/docs/concepts/PSRule/en-US/about_PSRule_Assert.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Assert.md
@@ -1,0 +1,191 @@
+# PSRule_Assert
+
+## about_PSRule_Assert
+
+## SHORT DESCRIPTION
+
+Describes the assertion helper that can be used within PSRule rule definitions.
+
+## LONG DESCRIPTION
+
+PSRule includes an assertion helper exposed as a built-in variable `$Assert`. The `$Assert` object provides a consistent set of methods to evaluate objects.
+
+Each `$Assert` method returns an `AssertResult` object that contains the result of the condition.
+
+The following built-in assertion methods are provided:
+
+- [HasField](#hasfield) - Asserts that the object must have the specified field.
+- [HasFieldValue](#hasfieldvalue) - Asserts that the object must have the specified field and that field is not empty.
+- [JsonSchema](#jsonschema) - Validates an object against a JSON schema.
+- [NullOrEmpty](#nullorempty) - Asserts that the object must not have the specified field or it must be empty.
+
+The `$Assert` variable can only be used within a rule definition block.
+
+### Using assertion methods
+
+An assertion method can be used like other methods in PowerShell. i.e. `$Assert.methodName(parameters)`.
+
+Assertion methods use the following standard pattern:
+
+- The first parameter is _always_ the input object of type `PSObject`, additional parameters can be included based on the functionality required by the method.
+  - In many cases the input object will be `$TargetObject`, however assertion methods must not assume that `$TargetObject` will be used.
+  - Assertion methods must not assume that the input object is not `$Null`.
+- Assertion methods return the `AssertResult` object that is interpreted by the rule pipeline.
+
+Some assertion methods may overlap or provide similar functionality to built-in keywords. Where you have the choice, use built-in keywords. Use assertion methods for advanced cases or increased flexibility.
+
+In the following example, `Assert.HasFieldValue` asserts that `$TargetObject` should have a field named `Type` with a non-empty value.
+
+```powershell
+Rule 'Assert.HasTypeField' {
+    $Assert.HasFieldValue($TargetObject, 'Type')
+}
+```
+
+To find perform multiple assertions use.
+
+```powershell
+Rule 'Assert.HasRequiredFields' {
+    $Assert.HasFieldValue($TargetObject, 'Name')
+    $Assert.HasFieldValue($TargetObject, 'Type')
+    $Assert.HasFieldValue($TargetObject, 'Value')
+}
+```
+
+### HasField
+
+The `HasField` assertion method checks the object has the specified field.
+
+The following parameters are accepted:
+
+- `inputObject` - The object being checked for the specified field.
+- `field` - The name of the field to check. By default a case insensitive compare is used.
+- `caseSensitive` (optional) - Use a case sensitive compare of the field name instead.
+
+Examples:
+
+```powershell
+Rule 'HasField' {
+    $Assert.HasField($TargetObject, 'Name')
+    $Assert.HasField($TargetObject, 'tag.Environment', $True)
+}
+```
+
+### HasFieldValue
+
+The `HasFieldValue` assertion method checks the field value of the object is not empty.
+
+A field value is empty if any of the following are true:
+
+- The field does not exist.
+- The field value is `$Null`.
+- The field value is an empty array or collection.
+- The field value is an empty string `''`.
+
+The following parameters are accepted:
+
+- `inputObject` - The object being checked for the specified field.
+- `field` - The name of the field to check. This is a case insensitive compare.
+- `expectedValue` (optional) - Check that the field value is set to a specific value. To check `$Null` use `NullOrEmpty` instead. If `expectedValue` is `$Null` the field value will not be compared.
+
+Examples:
+
+```powershell
+Rule 'HasFieldValue' {
+    $Assert.HasFieldValue($TargetObject, 'Name')
+    $Assert.HasFieldValue($TargetObject, 'tag.Environment', 'production')
+}
+```
+
+### JsonSchema
+
+The `JsonSchema` assertion method allows an object to validated against a defined JSON schema.
+
+The following parameters are accepted:
+
+- `inputObject` - The object being compared against the JSON schema.
+- `uri` - A URL or file path to a JSON schema file formatted as UTF-8.
+
+Examples:
+
+```powershell
+Rule 'JsonSchema' {
+    $Assert.JsonSchema($TargetObject, 'tests/PSRule.Tests/FromFile.Json.schema.json')
+}
+```
+
+### NullOrEmpty
+
+The `NullOrEmpty` assertion method checks the field value of the object is null or empty.
+
+A field value is null or empty if any of the following are true:
+
+- The field does not exist.
+- The field value is `$Null`.
+- The field value is an empty array or collection.
+- The field value is an empty string `''`.
+
+The following parameters are accepted:
+
+- `inputObject` - The object being checked for the specified field.
+- `field` - The name of the field to check. This is a case insensitive compare.
+
+Examples:
+
+```powershell
+Rule 'NullOrEmpty' {
+    $Assert.NullOrEmpty($TargetObject, 'Name')
+    $Assert.NullOrEmpty($TargetObject, 'tag.Environment')
+}
+```
+
+### Advanced usage
+
+The `AssertResult` object returned from assertion methods allows:
+
+- Handles pass/ fail conditions and collection of reason information.
+- Allows rules to implement their own handling or forward it up the stack to affect the rule outcome.
+
+The following properties are available:
+
+- `Result` - Either `$True` (Pass) or `$False` (Fail).
+
+The following methods are available:
+
+- `AddReason(<string> text)` - Can be used to add additional reasons to the result. A reason can only be set if the assertion failed. Reason text should be localized before calling this method. Localization can be done using the `$LocalizedData` automatic variable.
+- `GetReason()` - Gets any reasons currently associated with the failed result.
+- `Complete()` - Returns `$True` (Pass) or `$False` (Fail) to the rule record. If the assertion failed, any reasons that are automatically added to the rule record.
+- `Ignore()` - Ignores the result. This method is use when implementing custom handling.
+
+Use of `Complete()` is optional, uncompleted results are automatically completed after the rule has executed. Uncompleted results may return reason messages out of sequence.
+
+In this example `Complete()` is used to find the first field with an empty value.
+
+```powershell
+Rule 'Assert.HasFieldValue' {
+    $Assert.HasFieldValue($TargetObject, 'Name').Complete() -and
+        $Assert.HasFieldValue($TargetObject, 'Type').Complete() -and
+        $Assert.HasFieldValue($TargetObject, 'Value').Complete()
+}
+```
+
+### Authoring assertion methods
+
+The following built-in helper methods are provided for working with `AssertResult` when authoring new assertion methods:
+
+- `Create(<bool> condition, <string> reason)` - Returns a result either pass or fail.
+- `Pass()` - Returns a pass result.
+- `Fail(<string> reason)` - Results a fail result.
+
+## NOTE
+
+An online version of this document is available at https://github.com/BernieWhite/PSRule/blob/master/docs/concepts/PSRule/en-US/about_PSRule_Assert.md.
+
+## SEE ALSO
+
+- [about_PSRule_Variables](https://github.com/BernieWhite/PSRule/blob/master/docs/concepts/PSRule/en-US/about_PSRule_Variables.md)
+
+## KEYWORDS
+
+- Assert
+- Rule

--- a/docs/concepts/PSRule/en-US/about_PSRule_Variables.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Variables.md
@@ -16,10 +16,44 @@ These variables are only available while `Invoke-PSRule` is executing.
 
 The following variables are available for use:
 
+- [$Assert](#assert)
 - [$Configuration](#configuration)
 - [$LocalizedData](#localizeddata)
 - [$Rule](#rule)
 - [$TargetObject](#targetobject)
+
+### Assert
+
+An assertion helper with methods to evaluate objects. The `$Assert` object provides a set of built-in methods and provides a consistent variable for extension.
+
+Each `$Assert` method returns an `AssertResult` object that contains the result of the condition.
+
+The following built-in assertion methods are provided:
+
+- `JsonSchema` - Validates an object against a JSON schema.
+
+The following built-in helper methods are provided for working with `AssertResult`:
+
+- `Create` - Returns a result either pass or fail.
+- `Pass` - Returns a pass result.
+- `Fail` - Results a fail result.
+
+For detailed information on the assertion helper see [about_PSRule_Assert](about_PSRule_Assert.md).
+
+Syntax:
+
+```powershell
+$Assert
+```
+
+Examples:
+
+```powershell
+# Synopsis: Determine if $TargetObject is valid against the provided schema
+Rule 'UseJsonSchema' {
+    $Assert.JsonSchema('schemas/PSRule-options.schema.json')
+}
+```
 
 ### Configuration
 

--- a/pipeline.build.ps1
+++ b/pipeline.build.ps1
@@ -128,6 +128,7 @@ task BuildHelp BuildModule, PlatyPS, {
     # Copy generated help into module out path
     $Null = Copy-Item -Path out/docs/PSRule/* -Destination out/modules/PSRule/en-US;
     $Null = Copy-Item -Path out/docs/PSRule/* -Destination out/modules/PSRule/en-AU;
+    $Null = Copy-Item -Path out/docs/PSRule/* -Destination out/modules/PSRule/en-GB;
 }
 
 task ScaffoldHelp Build, {

--- a/src/PSRule/Common/PSObjectExtensions.cs
+++ b/src/PSRule/Common/PSObjectExtensions.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using System;
+using System.Globalization;
 using System.Management.Automation;
 
 namespace PSRule
@@ -49,6 +51,13 @@ namespace PSRule
 
             value = p.Value;
             return true;
+        }
+
+        public static string ToJson(this PSObject o)
+        {
+            var settings = new JsonSerializerSettings { Formatting = Formatting.None, TypeNameHandling = TypeNameHandling.None, MaxDepth = 1024, Culture = CultureInfo.InvariantCulture };
+            settings.Converters.Insert(0, new PSObjectJsonConverter());
+            return JsonConvert.SerializeObject(o, settings);
         }
     }
 }

--- a/src/PSRule/Common/StringExtensions.cs
+++ b/src/PSRule/Common/StringExtensions.cs
@@ -1,0 +1,10 @@
+﻿namespace PSRule
+{
+    internal static class StringExtensions
+    {
+        public static bool IsUri(this string s)
+        {
+            return s.StartsWith("http://") || s.StartsWith("https://");
+        }
+    }
+}

--- a/src/PSRule/PSRule.csproj
+++ b/src/PSRule/PSRule.csproj
@@ -23,6 +23,7 @@ This project is to be considered a proof-of-concept and not a supported product.
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Manatee.Json" Version="11.0.0-beta6" />
     <PackageReference Include="PowerShellStandard.Library" Version="5.1.0" PrivateAssets="All" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="YamlDotNet" Version="5.0.1" />

--- a/src/PSRule/Pipeline/PipelineContext.cs
+++ b/src/PSRule/Pipeline/PipelineContext.cs
@@ -132,6 +132,7 @@ namespace PSRule.Pipeline
                 _Runspace.SessionStateProxy.PSVariable.Set("WarningPreference", ActionPreference.Continue);
                 _Runspace.SessionStateProxy.PSVariable.Set("VerbosePreference", ActionPreference.Continue);
                 _Runspace.SessionStateProxy.PSVariable.Set("DebugPreference", ActionPreference.Continue);
+                _Runspace.SessionStateProxy.Path.SetLocation(PSRuleOption.GetWorkingPath());
             }
 
             return _Runspace;

--- a/src/PSRule/Pipeline/PowerShellPipelineStream.cs
+++ b/src/PSRule/Pipeline/PowerShellPipelineStream.cs
@@ -2,12 +2,10 @@
 using PSRule.Configuration;
 using PSRule.Rules;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Management.Automation;
-using System.Text;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 
@@ -51,7 +49,7 @@ namespace PSRule.Pipeline
 
                 foreach (var p in _InputPath)
                 {
-                    if (p.StartsWith("http://") || p.StartsWith("https://"))
+                    if (p.IsUri())
                     {
                         Manager.Process(targetObject: PSObject.AsPSObject(new Uri(p)));
                     }

--- a/src/PSRule/Resources/PSRuleResources.Designer.cs
+++ b/src/PSRule/Resources/PSRuleResources.Designer.cs
@@ -277,6 +277,15 @@ namespace PSRule.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The variable &apos;${0}&apos; can only be used within a Rule block..
+        /// </summary>
+        internal static string VariableConditionScope {
+            get {
+                return ResourceManager.GetString("VariableConditionScope", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Within: {0}.
         /// </summary>
         internal static string WithinTrue {

--- a/src/PSRule/Resources/PSRuleResources.resx
+++ b/src/PSRule/Resources/PSRuleResources.resx
@@ -195,6 +195,9 @@
   <data name="ShouldWriteFile" xml:space="preserve">
     <value>Write file</value>
   </data>
+  <data name="VariableConditionScope" xml:space="preserve">
+    <value>The variable '${0}' can only be used within a Rule block.</value>
+  </data>
   <data name="WithinTrue" xml:space="preserve">
     <value>Within: {0}</value>
   </data>

--- a/src/PSRule/Resources/ReasonStrings.Designer.cs
+++ b/src/PSRule/Resources/ReasonStrings.Designer.cs
@@ -79,6 +79,51 @@ namespace PSRule.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The field &apos;{0}&apos; is set to &apos;{1}&apos;..
+        /// </summary>
+        internal static string HasExpectedFieldValue {
+            get {
+                return ResourceManager.GetString("HasExpectedFieldValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The field &apos;{0}&apos; does not exist..
+        /// </summary>
+        internal static string HasField {
+            get {
+                return ResourceManager.GetString("HasField", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The value of &apos;{0}&apos; is null or empty..
+        /// </summary>
+        internal static string HasFieldValue {
+            get {
+                return ResourceManager.GetString("HasFieldValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed schema validation on {0}. {1}.
+        /// </summary>
+        internal static string JsonSchemaInvalid {
+            get {
+                return ResourceManager.GetString("JsonSchemaInvalid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The JSON schema &apos;{0}&apos; chould not be found..
+        /// </summary>
+        internal static string JsonSchemaNotFound {
+            get {
+                return ResourceManager.GetString("JsonSchemaNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to None of the regex(s) matched: {0}.
         /// </summary>
         internal static string Match {
@@ -93,6 +138,33 @@ namespace PSRule.Resources {
         internal static string MatchNot {
             get {
                 return ResourceManager.GetString("MatchNot", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The field &apos;{0}&apos; is not empty..
+        /// </summary>
+        internal static string NullOrEmpty {
+            get {
+                return ResourceManager.GetString("NullOrEmpty", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The parameter &apos;{0}&apos; is null or empty..
+        /// </summary>
+        internal static string NullOrEmptyParameter {
+            get {
+                return ResourceManager.GetString("NullOrEmptyParameter", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The parameter &apos;{0}&apos; is null..
+        /// </summary>
+        internal static string NullParameter {
+            get {
+                return ResourceManager.GetString("NullParameter", resourceCulture);
             }
         }
         

--- a/src/PSRule/Resources/ReasonStrings.resx
+++ b/src/PSRule/Resources/ReasonStrings.resx
@@ -125,6 +125,21 @@
     <value>The field '{0}' exists.</value>
     <comment>Included when any of the fields exist and the -Not switch is used.</comment>
   </data>
+  <data name="HasExpectedFieldValue" xml:space="preserve">
+    <value>The field '{0}' is set to '{1}'.</value>
+  </data>
+  <data name="HasField" xml:space="preserve">
+    <value>The field '{0}' does not exist.</value>
+  </data>
+  <data name="HasFieldValue" xml:space="preserve">
+    <value>The value of '{0}' is null or empty.</value>
+  </data>
+  <data name="JsonSchemaInvalid" xml:space="preserve">
+    <value>Failed schema validation on {0}. {1}</value>
+  </data>
+  <data name="JsonSchemaNotFound" xml:space="preserve">
+    <value>The JSON schema '{0}' chould not be found.</value>
+  </data>
   <data name="Match" xml:space="preserve">
     <value>None of the regex(s) matched: {0}</value>
     <comment>Incldued when none of the regular expressions match.</comment>
@@ -132,6 +147,15 @@
   <data name="MatchNot" xml:space="preserve">
     <value>The regex '{0}' matched.</value>
     <comment>Included when any of the regular expressions match and the -Not switch is used.</comment>
+  </data>
+  <data name="NullOrEmpty" xml:space="preserve">
+    <value>The field '{0}' is not empty.</value>
+  </data>
+  <data name="NullOrEmptyParameter" xml:space="preserve">
+    <value>The parameter '{0}' is null or empty.</value>
+  </data>
+  <data name="NullParameter" xml:space="preserve">
+    <value>The parameter '{0}' is null.</value>
   </data>
   <data name="TypeOf" xml:space="preserve">
     <value>None of the type name(s) match: {0}</value>

--- a/src/PSRule/Rules/RuleConditionResult.cs
+++ b/src/PSRule/Rules/RuleConditionResult.cs
@@ -1,4 +1,5 @@
 ﻿using PSRule.Pipeline;
+using PSRule.Runtime;
 using System.Collections.Generic;
 using System.Management.Automation;
 
@@ -43,7 +44,7 @@ namespace PSRule.Rules
                 {
                     continue;
                 }
-                else if (!TryBoolean(v, out bool bresult))
+                else if (!(TryAssertResult(v, out bool bresult) || TryBoolean(v, out bresult)))
                 {
                     PipelineContext.CurrentThread.ErrorInvaildRuleResult();
 
@@ -76,6 +77,31 @@ namespace PSRule.Rules
             if (o is PSObject pso && pso.BaseObject is bool psoresult)
             {
                 result = psoresult;
+                return true;
+            }
+
+            return false;
+        }
+
+        private static bool TryAssertResult(object o, out bool result)
+        {
+            result = false;
+
+            if (o == null)
+            {
+                return false;
+            }
+
+            // Complete results
+            if (o is AssertResult aresult)
+            {
+                result = aresult.Complete();
+                return true;
+            }
+
+            if (o is PSObject pso && pso.BaseObject is AssertResult psoresult)
+            {
+                result = psoresult.Complete();
                 return true;
             }
 

--- a/src/PSRule/Runtime/Assert.cs
+++ b/src/PSRule/Runtime/Assert.cs
@@ -1,9 +1,227 @@
-﻿namespace PSRule.Runtime
+﻿using Manatee.Json;
+using Manatee.Json.Schema;
+using Manatee.Json.Serialization;
+using PSRule.Configuration;
+using PSRule.Pipeline;
+using PSRule.Resources;
+using System;
+using System.Collections;
+using System.IO;
+using System.Management.Automation;
+using System.Net;
+
+namespace PSRule.Runtime
 {
     /// <summary>
     /// A helper variable exposed at runtime for rules.
     /// </summary>
     public sealed class Assert
     {
+        public AssertResult Create(bool condition, string reason = null)
+        {
+            if (PipelineContext.CurrentThread.ExecutionScope != ExecutionScope.Condition)
+            {
+                throw new RuleRuntimeException(string.Format(PSRuleResources.VariableConditionScope, "Assert"));
+            }
+            return new AssertResult(this, condition, reason);
+        }
+
+        public AssertResult Pass()
+        {
+            return Create(condition: true);
+        }
+
+        public AssertResult Fail(string reason = null)
+        {
+            return Create(condition: false, reason: reason);
+        }
+
+        public AssertResult JsonSchema(PSObject inputObject, string uri)
+        {
+            // Guard parameters
+            if (TryNull(inputObject, nameof(inputObject), out AssertResult result) || TryNullOrEmpty(uri, nameof(uri), out result))
+            {
+                return result;
+            }
+
+            // Get the schema
+            if (!(TryReadJson(uri, out string schemaContent)))
+            {
+                return Fail(reason: string.Format(ReasonStrings.JsonSchemaNotFound, uri));
+            }
+
+            var s = new JsonSerializer();
+            JsonSchemaOptions.OutputFormat = SchemaValidationOutputFormat.Basic;
+            var schema = s.Deserialize<JsonSchema>(JsonValue.Parse(schemaContent));
+
+            // Get the TargetObject
+            var json = JsonValue.Parse(inputObject.ToJson());
+
+            // Validate
+            var schemaResults = schema.Validate(json);
+
+            // Schema is valid
+            if (schemaResults.IsValid)
+            {
+                return Pass();
+            }
+
+            // Handle schema invalid
+            result = Fail();
+
+            if (!string.IsNullOrEmpty(schemaResults.ErrorMessage))
+            {
+                result.AddReason(string.Format(ReasonStrings.JsonSchemaInvalid, schemaResults.InstanceLocation.ToString(), schemaResults.ErrorMessage));
+            }
+
+            foreach (var r in schemaResults.NestedResults)
+            {
+                if (!string.IsNullOrEmpty(r.ErrorMessage))
+                {
+                    result.AddReason(string.Format(ReasonStrings.JsonSchemaInvalid, r.InstanceLocation.ToString(), r.ErrorMessage));
+                }
+            }
+            return result;
+        }
+
+        public AssertResult HasField(PSObject inputObject, string field, bool caseSensitive = false)
+        {
+            // Guard parameters
+            if (TryNull(inputObject, nameof(inputObject), out AssertResult result) || TryNullOrEmpty(field, nameof(field), out result))
+            {
+                return result;
+            }
+
+            // Assert
+            if (!ObjectHelper.GetField(bindingContext: PipelineContext.CurrentThread, targetObject: inputObject, name: field, caseSensitive: caseSensitive, value: out object fieldValue))
+            {
+                return Fail(string.Format(ReasonStrings.HasField, field));
+            }
+            return Pass();
+        }
+
+        public AssertResult HasFieldValue(PSObject inputObject, string field, object expectedValue = null)
+        {
+            // Guard parameters
+            if (TryNull(inputObject, nameof(inputObject), out AssertResult result) || TryNullOrEmpty(field, nameof(field), out result))
+            {
+                return result;
+            }
+
+            // Assert
+            if (!ObjectHelper.GetField(bindingContext: PipelineContext.CurrentThread, targetObject: inputObject, name: field, caseSensitive: false, value: out object fieldValue))
+            {
+                return Fail(string.Format(ReasonStrings.HasField, field));
+            }
+            else if (IsEmpty(fieldValue))
+            {
+                return Fail(string.Format(ReasonStrings.HasFieldValue, field));
+            }
+            else if (expectedValue != null && !IsValue(fieldValue, expectedValue))
+            {
+                return Fail(string.Format(ReasonStrings.HasExpectedFieldValue, field, fieldValue));
+            }
+            return Pass();
+        }
+
+        public AssertResult NullOrEmpty(PSObject inputObject, string field)
+        {
+            // Guard parameters
+            if (TryNull(inputObject, nameof(inputObject), out AssertResult result) || TryNullOrEmpty(field, nameof(field), out result))
+            {
+                return result;
+            }
+
+            // Assert
+            if (ObjectHelper.GetField(bindingContext: PipelineContext.CurrentThread, targetObject: inputObject, name: field, caseSensitive: false, value: out object fieldValue) && !IsEmpty(fieldValue))
+            { 
+                return Fail(string.Format(ReasonStrings.NullOrEmpty, field));
+            }
+            return Pass();
+        }
+
+        private bool IsEmpty(object fieldValue)
+        {
+            return fieldValue == null ||
+                (fieldValue is ICollection cvalue && cvalue.Count == 0) ||
+                (fieldValue is string svalue && string.IsNullOrEmpty(svalue));
+        }
+
+        private bool IsValue(object fieldValue, object expectedValue)
+        {
+            // Unwrap as required
+            var expectedBase = expectedValue;
+            if (expectedValue is PSObject pso)
+            {
+                expectedBase = pso.BaseObject;
+            }
+
+            if (fieldValue is string && expectedBase is string)
+            {
+                return StringComparer.OrdinalIgnoreCase.Equals(fieldValue, expectedBase);
+            }
+            else if (expectedBase.Equals(fieldValue))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private bool TryNull(object value, string parameterName, out AssertResult result)
+        {
+            result = value == null ? FailNull(parameterName) : null;
+            return result != null;
+        }
+
+        private bool TryNullOrEmpty(string value, string parameterName, out AssertResult result)
+        {
+            result = string.IsNullOrEmpty(value) ? FailNullOrEmpty(parameterName) : null;
+            return result != null;
+        }
+
+        private AssertResult FailNull(string parameterName)
+        {
+            return Fail(reason: string.Format(ReasonStrings.NullParameter, parameterName));
+        }
+
+        private AssertResult FailNullOrEmpty(string parameterName)
+        {
+            return Fail(reason: string.Format(ReasonStrings.NullOrEmptyParameter, parameterName));
+        }
+
+        private bool TryReadJson(string uri, out string json)
+        {
+            json = null;
+
+            if (uri == null)
+            {
+                return false;
+            }
+            else if (uri.IsUri())
+            {
+                using (var webClient = new WebClient())
+                {
+                    json = webClient.DownloadString(uri);
+                    return true;
+                }
+            }
+            else if (TryFilePath(uri, out string path))
+            {
+                using (var reader = new StreamReader(path))
+                {
+                    json = reader.ReadToEnd();
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private bool TryFilePath(string uri, out string path)
+        {
+            path = PSRuleOption.GetRootedPath(uri);
+            return File.Exists(path);
+        }
     }
 }

--- a/src/PSRule/Runtime/AssertResult.cs
+++ b/src/PSRule/Runtime/AssertResult.cs
@@ -1,0 +1,95 @@
+﻿using PSRule.Pipeline;
+using PSRule.Resources;
+using System;
+using System.Collections.Generic;
+
+namespace PSRule.Runtime
+{
+    public sealed class AssertResult : IEquatable<bool>
+    {
+        private readonly Assert _Assert;
+        private readonly List<string> _Reason;
+
+        internal AssertResult(Assert assert, bool value, string reason)
+        {
+            _Assert = assert;
+            Result = value;
+
+            if (!Result)
+            {
+                _Reason = new List<string>();
+                if (!string.IsNullOrEmpty(reason))
+                {
+                    _Reason.Add(reason);
+                }
+            }
+        }
+
+        public static explicit operator bool(AssertResult result)
+        {
+            return result.Result;
+        }
+
+        /// <summary>
+        /// Success of the condition. True indicate pass, false indicates fail.
+        /// </summary>
+        public bool Result { get; private set; }
+
+        /// <summary>
+        /// Add a reason.
+        /// </summary>
+        /// <param name="text">The text of a reason to add. This text should already be localized for the currently culture.</param>
+        public void AddReason(string text)
+        {
+            // Ignore reasons if this is a pass.
+            if (Result)
+            {
+                return;
+            }
+            _Reason.Add(text);
+        }
+
+        /// <summary>
+        /// Get an reasons that are currently set.
+        /// </summary>
+        /// <returns>Returns an array of reasons. This will always return null when the Value is true.</returns>
+        public string[] GetReason()
+        {
+            if (!Result || _Reason == null || _Reason.Count == 0)
+            {
+                return null;
+            }
+            return _Reason.ToArray();
+        }
+
+        /// <summary>
+        /// Complete an assertion by writing an provided reasons and returning a boolean.
+        /// </summary>
+        /// <returns>Returns true or false.</returns>
+        public bool Complete()
+        {
+            // Check that the scope is still valid
+            if (PipelineContext.CurrentThread.ExecutionScope != ExecutionScope.Condition)
+            {
+                throw new RuleRuntimeException(string.Format(PSRuleResources.VariableConditionScope, "Assert"));
+            }
+
+            // Continue
+            for (var i = 0; _Reason != null && i < _Reason.Count; i++)
+            {
+                PipelineContext.CurrentThread.WriteReason(_Reason[i]);
+            }
+            return Result;
+        }
+
+        public void Ignore()
+        {
+            _Reason.Clear();
+        }
+
+        public bool Equals(bool other)
+        {
+            return Result == other;
+        }
+    }
+}

--- a/tests/PSRule.Tests/FromFile.Json.schema.json
+++ b/tests/PSRule.Tests/FromFile.Json.schema.json
@@ -1,0 +1,30 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Unit test schema",
+    "description": "A schema for PSRule YAML options files.",
+    "oneOf": [
+        {
+            "$ref": "#/definitions/structure"
+        }
+    ],
+    "definitions": {
+        "structure": {
+            "type": "object",
+            "properties": {
+                "Name": {
+                    "type": "string",
+                    "enum": [
+                        "TestObject1"
+                    ]
+                },
+                "Type": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Name"
+            ]
+        }
+    }
+}

--- a/tests/PSRule.Tests/FromFile.Rule.ps1
+++ b/tests/PSRule.Tests/FromFile.Rule.ps1
@@ -147,6 +147,22 @@ Rule 'WithLocalizedData' {
     $LocalizedData.WithLocalizedDataMessage -like "LocalizedMessage for en-*"
 }
 
+# Synopsis: Test $PSScriptRoot automatic variable
+Rule 'WithPSScriptRoot' {
+    $PSScriptRoot -eq $TargetObject.PSScriptRoot
+}
+
+# Synopsis: Test $PWD automatic variable
+Rule 'WithPWD' {
+    $PWD.ToString() -eq $TargetObject.PWD.ToString()
+
+}
+
+# Synopsis: Test $WithPSCommandPath automatic variable
+Rule 'WithPSCommandPath' {
+    $WithPSCommandPath -eq $TargetObject.WithPSCommandPath
+}
+
 Rule 'WithCsv' {
     $True;
 }

--- a/tests/PSRule.Tests/FromFileAssert.Rule.ps1
+++ b/tests/PSRule.Tests/FromFileAssert.Rule.ps1
@@ -1,0 +1,54 @@
+#
+# Pester unit test rules for the assertion helper
+#
+
+Add-Member -InputObject $Assert -MemberType ScriptMethod -Name '_ExtensionIsValue' -Value {
+    param ($value, $s)
+    return $this.Create(("MethodValue$value" -eq $s))
+}
+
+# Synopsis: Test for $Assert extension with Add-Member
+Rule 'Assert.AddMember' {
+    $Assert._ExtensionIsValue(1, 'MethodValue1')
+    $Assert._ExtensionIsValue(2, 'MethodValue2')
+}
+
+# Synopsis: Test for $Assert.Complete
+Rule 'Assert.Complete' {
+    $Assert.HasField($TargetObject, 'Name').Complete() -and
+        $Assert.HasField($TargetObject, 'Type').Complete() -and
+        $Assert.HasField($TargetObject, 'OtherField').Complete()
+}
+
+# Synopsis: Test for $Assert.JsonSchema
+Rule 'Assert.JsonSchema' {
+    $Assert.JsonSchema($TargetObject, 'tests/PSRule.Tests/FromFile.Json.schema.json')
+}
+
+# Synopsis: Test for $Assert.HasField
+Rule 'Assert.HasField' {
+    $Assert.HasField($TargetObject, 'Type')
+}
+
+# Synopsis: Test for $Assert.HasFieldValue
+Rule 'Assert.HasFieldValue' {
+    AnyOf {
+        $Assert.HasFieldValue($TargetObject, 'Type')
+        $Assert.HasFieldValue($TargetObject, 'Value')
+        $Assert.HasFieldValue($TargetObject, 'String')
+        $Assert.HasFieldValue($TargetObject, 'Array')
+        $Assert.HasFieldValue($TargetObject, 'Name', 'TestObject1')
+        $Assert.HasFieldValue($TargetObject, 'Int', 1)
+        $Assert.HasFieldValue($TargetObject, 'Bool', $True)
+    }
+}
+
+# Synopsis: Test for $Assert.HasEmptyField
+Rule 'Assert.NullOrEmpty' {
+    AllOf {
+        $Assert.NullOrEmpty($TargetObject, 'Type')
+        $Assert.NullOrEmpty($TargetObject, 'Value')
+        $Assert.NullOrEmpty($TargetObject, 'String')
+        $Assert.NullOrEmpty($TargetObject, 'Array')
+    }
+}

--- a/tests/PSRule.Tests/PSRule.Assert.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Assert.Tests.ps1
@@ -1,0 +1,156 @@
+#
+# Unit tests for PSRule $Assert
+#
+
+[CmdletBinding()]
+param (
+
+)
+
+# Setup error handling
+$ErrorActionPreference = 'Stop';
+Set-StrictMode -Version latest;
+
+if ($Env:SYSTEM_DEBUG -eq 'true') {
+    $VerbosePreference = 'Continue';
+}
+
+# Setup tests paths
+$rootPath = $PWD;
+
+Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule) -Force;
+$here = (Resolve-Path $PSScriptRoot).Path;
+
+#region PSRule variables
+
+Describe 'PSRule assertions' -Tag 'Assert' {
+    $ruleFilePath = (Join-Path -Path $here -ChildPath 'FromFileAssert.Rule.ps1');
+
+    Context '$Assert' {
+        $testObject = @(
+            [PSCustomObject]@{
+                Name = 'TestObject1'
+                Type = 'TestType'
+                Value = 'Value1'
+                Array = 'Item1', 'Item2'
+                String = 'Value'
+                OtherField = 'Other'
+                Int = 1
+                Bool = $True
+            }
+            [PSCustomObject]@{
+                Name = 'TestObject2'
+                NotType = 'TestType'
+                Value = $Null
+                Array = @()
+                String = ''
+                Int = 2
+                Bool = $False
+            }
+        )
+
+        It 'Complete' {
+            $result = @($testObject | Invoke-PSRule -Path $ruleFilePath -Name 'Assert.Complete');
+            $result | Should -Not -BeNullOrEmpty;
+            $result.Length | Should -Be 2;
+
+            # Positive case
+            $result[0].IsSuccess() | Should -Be $True;
+            $result[0].TargetName | Should -Be 'TestObject1';
+
+            # Negative case
+            $result[1].IsSuccess() | Should -Be $False;
+            $result[1].TargetName | Should -Be 'TestObject2';
+            $result[1].Reason.Length | Should -Be 1;
+            $result[1].Reason | Should -Be 'The field ''Type'' does not exist.';
+        }
+
+        It 'JsonSchema' {
+            $result = @($testObject | Invoke-PSRule -Path $ruleFilePath -Name 'Assert.JsonSchema');
+            $result | Should -Not -BeNullOrEmpty;
+            $result.Length | Should -Be 2;
+
+            # Positive case
+            $result[0].IsSuccess() | Should -Be $True;
+            $result[0].TargetName | Should -Be 'TestObject1';
+
+            # Negative case
+            $result[1].IsSuccess() | Should -Be $False;
+            $result[1].TargetName | Should -Be 'TestObject2';
+            $result[1].Reason.Length | Should -Be 2;
+            $result[1].Reason | Should -BeLike "Failed schema validation on `#*. *";
+        }
+
+        It 'HasField' {
+            $result = @($testObject | Invoke-PSRule -Path $ruleFilePath -Name 'Assert.HasField');
+            $result | Should -Not -BeNullOrEmpty;
+            $result.Length | Should -Be 2;
+
+            # Positive case
+            $result[0].IsSuccess() | Should -Be $True;
+            $result[0].TargetName | Should -Be 'TestObject1';
+
+            # Negative case
+            $result[1].IsSuccess() | Should -Be $False;
+            $result[1].TargetName | Should -Be 'TestObject2';
+            $result[1].Reason.Length | Should -Be 1;
+            $result[1].Reason | Should -BeLike "The field '*' does not exist.";
+        }
+
+        It 'HasFieldValue' {
+            $result = @($testObject | Invoke-PSRule -Path $ruleFilePath -Name 'Assert.HasFieldValue');
+            $result | Should -Not -BeNullOrEmpty;
+            $result.Length | Should -Be 2;
+
+            # Positive case
+            $result[0].IsSuccess() | Should -Be $True;
+            $result[0].TargetName | Should -Be 'TestObject1';
+
+            # Negative case
+            $result[1].IsSuccess() | Should -Be $False;
+            $result[1].TargetName | Should -Be 'TestObject2';
+            $result[1].Reason.Length | Should -Be 7;
+            $result[1].Reason[0] | Should -BeLike "The field '*' does not exist.";
+            $result[1].Reason[1..3] | Should -BeLike "The value of '*' is null or empty.";
+            $result[1].Reason[4..6] | Should -BeLike "The field '*' is set to '*'.";
+        }
+
+        It 'NullOrEmpty' {
+            $result = @($testObject | Invoke-PSRule -Path $ruleFilePath -Name 'Assert.NullOrEmpty');
+            $result | Should -Not -BeNullOrEmpty;
+            $result.Length | Should -Be 2;
+
+            # Positive case
+            $result[1].IsSuccess() | Should -Be $True;
+            $result[1].TargetName | Should -Be 'TestObject2';
+
+            # Negative case
+            $result[0].IsSuccess() | Should -Be $False;
+            $result[0].TargetName | Should -Be 'TestObject1';
+            $result[0].Reason.Length | Should -Be 4;
+            $result[0].Reason | Should -BeLike "The field '*' is not empty.";
+        }
+    }
+
+    Context '$Assert extension' {
+        $testObject = @(
+            [PSCustomObject]@{
+                Name = 'TestObject1'
+                Type = 'TestType'
+            }
+            [PSCustomObject]@{
+                Name = 'TestObject2'
+                NotType = 'TestType'
+            }
+        )
+
+        It 'With Add-Member' {
+            $result = @($testObject | Invoke-PSRule -Path $ruleFilePath -Name 'Assert.AddMember');
+            $result | Should -Not -BeNullOrEmpty;
+            $result.Length | Should -Be 2;
+            $result.IsSuccess() | Should -BeIn $True;
+        }
+    }
+}
+
+#endregion PSRule variables

--- a/tests/PSRule.Tests/PSRule.Variables.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Variables.Tests.ps1
@@ -2,6 +2,9 @@
 # Unit tests for PSRule variables
 #
 
+# Notes:
+# $Assert variable is included in PSRule.Assert.Tests.ps1
+
 [CmdletBinding()]
 param (
 
@@ -30,6 +33,9 @@ Describe 'PSRule variables' -Tag 'Variables' {
         $testObject = [PSCustomObject]@{
             Name = 'VariableTest'
             Type = 'TestType'
+            PSScriptRoot = $PSScriptRoot
+            PWD = $PWD
+            PSCommandPath = $ruleFilePath
         }
         $testObject.PSObject.TypeNames.Insert(0, $testObject.Type);
 
@@ -53,6 +59,24 @@ Describe 'PSRule variables' -Tag 'Variables' {
             $result.IsSuccess() | Should -Be $True;
             $result.TargetName | Should -Be 'VariableTest';
             $messages[0] | Should -Be 'LocalizedMessage for en-ZZ. Format=TestType.';
+        }
+
+        It '$PSScriptRoot' {
+            $result = $testObject | Invoke-PSRule -Path $ruleFilePath -Name 'WithPSScriptRoot';
+            $result | Should -Not -BeNullOrEmpty;
+            $result.IsSuccess() | Should -Be $True;
+        }
+
+        It '$PWD' {
+            $result = $testObject | Invoke-PSRule -Path $ruleFilePath -Name 'WithPWD';
+            $result | Should -Not -BeNullOrEmpty;
+            $result.IsSuccess() | Should -Be $True;
+        }
+
+        It '$PSCommandPath' {
+            $result = $testObject | Invoke-PSRule -Path $ruleFilePath -Name 'WithPSCommandPath';
+            $result | Should -Not -BeNullOrEmpty;
+            $result.IsSuccess() | Should -Be $True;
         }
     }
 }


### PR DESCRIPTION
## PR Summary

- Fix inconsistent handling of `$PWD`. #249
- Added assertion helper `$Assert` for extensibility. #250
  - Add built-in assertions for `HasField`, `HasFieldValue` and `NullOrEmpty`.
  - Add JSON schema assertion method `JsonSchema`. #42

Fixes #249 
Fixes #250 
Fixes #42 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/BernieWhite/PSRule/blob/master/CHANGELOG.md) has been updated with change under unreleased section
