### PR TITLE
Pre-release v0.8.0-B190742

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 
 ## Unreleased
 
+## v0.8.0-B190742 (pre-release)
+
 - Fix inconsistent handling of `$PWD`. [#249](https://github.com/BernieWhite/PSRule/issues/249)
 - Add detection for improper keyword use. [#203](https://github.com/BernieWhite/PSRule/issues/203)
 - Automatically load rule modules. [#218](https://github.com/BernieWhite/PSRule/issues/218)


### PR DESCRIPTION
## PR Summary

- Fix inconsistent handling of `$PWD`. #249
- Add detection for improper keyword use. #203
- Automatically load rule modules. #218
- Added assertion helper `$Assert` for extensibility. #250
  - Add built-in assertions for `HasField`, `HasFieldValue` and `NullOrEmpty`.
  - Add JSON schema assertion method `JsonSchema`. #42
- **Breaking change**: Use rule references consistent with cmdlet fully qualified syntax. #217
  - Previously rule names only had to be unique within a single file, now rule names have to be unique within the current execution path or within a module.
  - Previously the `filename.rule.ps1/RuleName` was supported to reference rules across files. Because rule names must be unique this syntax is no longer required or supported.
  - You can reference a rule from a loaded module by using the syntax `ModuleName\RuleName`.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
