### PR TITLE
Fix module reloading and finding rules #254 #256

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 
 ## Unreleased
 
+- Fix module reloading with different versions. [#254](https://github.com/BernieWhite/PSRule/issues/254)
+- Fix not finding rules in current path by default. [#256](https://github.com/BernieWhite/PSRule/issues/256)
+
 ## v0.8.0-B190742 (pre-release)
 
 - Fix inconsistent handling of `$PWD`. [#249](https://github.com/BernieWhite/PSRule/issues/249)


### PR DESCRIPTION
## PR Summary

- Fix module reloading with different versions. #254
- Fix not finding rules in current path by default. #256

Fixes #254 
Fixes #256 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/BernieWhite/PSRule/blob/master/CHANGELOG.md) has been updated with change under unreleased section
