### PR TITLE
Added rule info display name #276 #275

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 ## Unreleased
 
 - Added support for a wildcard match using the `Within` keyword. [#272](https://github.com/BernieWhite/PSRule/issues/272)
+- Added rule info display name. [#276](https://github.com/BernieWhite/PSRule/issues/276)
+- Fix ModuleName not displayed in Get-PSRuleHelp list. [#275](https://github.com/BernieWhite/PSRule/issues/275)
 
 ## v0.9.0-B190810 (pre-release)
 

--- a/src/PSRule/PSRule.Format.ps1xml
+++ b/src/PSRule/PSRule.Format.ps1xml
@@ -13,7 +13,29 @@
                   <LeftIndent>4</LeftIndent>
                   <CustomItem>
                     <ExpressionBinding>
-                      <PropertyName>NAME</PropertyName>
+                      <PropertyName>Name</PropertyName>
+                    </ExpressionBinding>
+                    <NewLine/>
+                  </CustomItem>
+                </Frame>
+              </CustomItem>
+            </CustomEntry>
+        </CustomEntries>
+      </CustomControl>
+    </Control>
+    <Control>
+      <Name>Help-DisplayName</Name>
+      <CustomControl>
+        <CustomEntries>
+          <CustomEntry>
+              <CustomItem>
+                <Text AssemblyName="PSRule" BaseName="PSRule.Resources.DocumentStrings" ResourceId="DisplayName"/>
+                <NewLine />
+                <Frame>
+                  <LeftIndent>4</LeftIndent>
+                  <CustomItem>
+                    <ExpressionBinding>
+                      <PropertyName>DisplayName</PropertyName>
                     </ExpressionBinding>
                     <NewLine/>
                   </CustomItem>
@@ -335,20 +357,28 @@
                     <CustomItem>
                       <NewLine />
                       <ExpressionBinding>
-                        <CustomControlName>Help-Synopsis</CustomControlName>
+                        <CustomControlName>Help-DisplayName</CustomControlName>
                       </ExpressionBinding>
                       <Frame>
                         <CustomItem>
                           <NewLine />
                           <ExpressionBinding>
-                            <CustomControlName>Help-Description</CustomControlName>
+                            <CustomControlName>Help-Synopsis</CustomControlName>
                           </ExpressionBinding>
                           <Frame>
                             <CustomItem>
                               <NewLine />
                               <ExpressionBinding>
-                                <CustomControlName>Help-Recommendation</CustomControlName>
+                                <CustomControlName>Help-Description</CustomControlName>
                               </ExpressionBinding>
+                              <Frame>
+                                <CustomItem>
+                                  <NewLine />
+                                  <ExpressionBinding>
+                                    <CustomControlName>Help-Recommendation</CustomControlName>
+                                  </ExpressionBinding>
+                                </CustomItem>
+                              </Frame>
                             </CustomItem>
                           </Frame>
                         </CustomItem>

--- a/src/PSRule/Resources/DocumentStrings.Designer.cs
+++ b/src/PSRule/Resources/DocumentStrings.Designer.cs
@@ -70,11 +70,29 @@ namespace PSRule.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to DISPLAY NAME.
+        /// </summary>
+        internal static string DisplayName {
+            get {
+                return ResourceManager.GetString("DisplayName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to RELATED LINKS.
         /// </summary>
         internal static string Links {
             get {
                 return ResourceManager.GetString("Links", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to MODULE NAME.
+        /// </summary>
+        internal static string ModuleName {
+            get {
+                return ResourceManager.GetString("ModuleName", resourceCulture);
             }
         }
         

--- a/src/PSRule/Resources/DocumentStrings.resx
+++ b/src/PSRule/Resources/DocumentStrings.resx
@@ -120,8 +120,14 @@
   <data name="Description" xml:space="preserve">
     <value>DESCRIPTION</value>
   </data>
+  <data name="DisplayName" xml:space="preserve">
+    <value>DISPLAY NAME</value>
+  </data>
   <data name="Links" xml:space="preserve">
     <value>RELATED LINKS</value>
+  </data>
+  <data name="ModuleName" xml:space="preserve">
+    <value>MODULE NAME</value>
   </data>
   <data name="Name" xml:space="preserve">
     <value>NAME</value>

--- a/src/PSRule/Rules/RuleHelpInfo.cs
+++ b/src/PSRule/Rules/RuleHelpInfo.cs
@@ -11,9 +11,11 @@ namespace PSRule.Rules
     {
         private const string ONLINE_HELP_LINK_ANNOTATION = "online version";
 
-        internal RuleHelpInfo(string name)
+        internal RuleHelpInfo(string name, string displayName, string moduleName)
         {
             Name = name;
+            DisplayName = displayName;
+            ModuleName = moduleName;
         }
 
         /// <summary>
@@ -21,6 +23,21 @@ namespace PSRule.Rules
         /// </summary>
         [JsonProperty(PropertyName = "name")]
         public string Name { get; private set; }
+
+        /// <summary>
+        /// A localized display name for the rule.
+        /// </summary>
+        [JsonProperty(PropertyName = "displayName")]
+        public string DisplayName { get; private set; }
+
+        /// <summary>
+        /// The name of the module.
+        /// </summary>
+        /// <remarks>
+        /// This will be null if the rule is not contained within a module.
+        /// </remarks>
+        [JsonProperty(PropertyName = "moduleName")]
+        public string ModuleName { get; private set; }
 
         /// <summary>
         /// The synopsis of the rule.

--- a/tests/PSRule.Tests/PSRule.Common.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Common.Tests.ps1
@@ -1224,6 +1224,8 @@ Describe 'Get-PSRuleHelp' -Tag 'Get-PSRuleHelp', 'Common' {
             $result = @(Get-PSRuleHelp -Name 'FromFile1' -Culture 'en-ZZ' -Path $ruleFilePath -WarningAction SilentlyContinue);
             $result.Length | Should -Be 1;
             $result[0].Name | Should -Be 'FromFile1';
+            $result[0].DisplayName | Should -Be 'Is FromFile1'
+            $result[0].ModuleName | Should -BeNullOrEmpty;
             $result[0].Synopsis | Should -Be 'This is a synopsis.';
             $result[0].Description | Should -Be 'This is a description.';
             $result[0].Recommendation | Should -Be 'This is a recommendation.';
@@ -1234,8 +1236,16 @@ Describe 'Get-PSRuleHelp' -Tag 'Get-PSRuleHelp', 'Common' {
 
     Context 'With -Module' {
         It 'Docs from module' {
-            $result = @(Get-PSRuleHelp -Module 'TestModule');
+            $result = @(Get-PSRuleHelp -Module 'TestModule' -Culture 'en-US');
             $result.Length | Should -Be 2;
+            $result[0].Name | Should -Be 'M1.Rule1';
+            $result[0].DisplayName | Should -Be 'Module Rule1';
+            $result[0].ModuleName | Should -Be 'TestModule';
+            $result[0].Synopsis | Should -Be 'Synopsis en-US.'
+            $result[0].Recommendation | Should -Be 'Recommendation en-US.'
+            $result[1].Name | Should -Be 'M1.Rule2';
+            $result[1].DisplayName | Should -Be 'M1.Rule2';
+            $result[1].ModuleName | Should -Be 'TestModule';
         }
     }
 

--- a/tests/PSRule.Tests/TestModule/en-AU/M1.Rule1.md
+++ b/tests/PSRule.Tests/TestModule/en-AU/M1.Rule1.md
@@ -3,7 +3,7 @@ culture: en-AU
 online version: https://github.com/BernieWhite/PSRule
 ---
 
-# M1.Rule1
+# Module Rule1
 
 ## Synopsis
 

--- a/tests/PSRule.Tests/TestModule/en-US/M1.Rule1.md
+++ b/tests/PSRule.Tests/TestModule/en-US/M1.Rule1.md
@@ -3,7 +3,7 @@ culture: en-US
 online version: https://github.com/BernieWhite/PSRule
 ---
 
-# M1.Rule1
+# Module Rule1
 
 ## Synopsis
 

--- a/tests/PSRule.Tests/en-ZZ/FromFile1.md
+++ b/tests/PSRule.Tests/en-ZZ/FromFile1.md
@@ -2,7 +2,7 @@
 culture: en-ZZ
 ---
 
-# FromFile1
+# Is FromFile1
 
 ## Synopsis
 


### PR DESCRIPTION
## PR Summary

- Added rule info display name. #276
- Fix ModuleName not displayed in Get-PSRuleHelp list. #275

Fixes #276 
Fixes #275 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/BernieWhite/PSRule/blob/master/CHANGELOG.md) has been updated with change under unreleased section
