### PR TITLE
Pre-release v0.9.0-B190819

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 
 ## Unreleased
 
+## v0.9.0-B190819 (pre-release)
+
 - Added support for a wildcard match using the `Within` keyword. [#272](https://github.com/BernieWhite/PSRule/issues/272)
 - Added rule info display name. [#276](https://github.com/BernieWhite/PSRule/issues/276)
 - Fix ModuleName not displayed in Get-PSRuleHelp list. [#275](https://github.com/BernieWhite/PSRule/issues/275)


### PR DESCRIPTION
## PR Summary

- Added support for a wildcard match using the `Within` keyword. #272
- Added rule info display name. #276
- Fix ModuleName not displayed in Get-PSRuleHelp list. #275

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
