### PR TITLE
Fix export of Like parameter for Within #279

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 
 ## Unreleased
 
+- Fix export of `Like` parameter for `Within` keyword. [#279](https://github.com/BernieWhite/PSRule/issues/279)
+
 ## v0.9.0-B190819 (pre-release)
 
 - Added support for a wildcard match using the `Within` keyword. [#272](https://github.com/BernieWhite/PSRule/issues/272)

--- a/src/PSRule/PSRule.psm1
+++ b/src/PSRule/PSRule.psm1
@@ -1109,15 +1109,18 @@ function Within {
         [Parameter(Mandatory = $True, Position = 0)]
         [String]$Field,
 
+        [Parameter(Mandatory = $False)]
+        [Switch]$Not = $False,
+
+        [Parameter(Mandatory = $False)]
+        [Switch]$Like = $False,
+
         [Parameter(Mandatory = $True, Position = 1)]
         [Alias('AllowedValue')]
         [PSObject[]]$Value,
 
         [Parameter(Mandatory = $False)]
         [Switch]$CaseSensitive = $False,
-
-        [Parameter(Mandatory = $False)]
-        [Switch]$Not = $False,
 
         [Parameter(Mandatory = $False)]
         [String]$Reason,


### PR DESCRIPTION
## PR Summary

- Fix export of `Like` parameter for `Within` keyword. #279

Fixes #279 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/BernieWhite/PSRule/blob/master/CHANGELOG.md) has been updated with change under unreleased section
