### PR TITLE
Pre-release v0.9.0-B190905

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 
 ## Unreleased
 
+## v0.9.0-B190905 (pre-release)
+
 - Added support for matching an array of tag values. [#282](https://github.com/BernieWhite/PSRule/issues/282)
 - Updated `Get-PSRuleHelp` to include help within the current path by default. [#197](https://github.com/BernieWhite/PSRule/issues/197)
 - Fix can not serialize nested System.IO.DirectoryInfo property. [#281](https://github.com/BernieWhite/PSRule/issues/281)


### PR DESCRIPTION
## PR Summary

- Added support for matching an array of tag values. #282
- Updated `Get-PSRuleHelp` to include help within the current path by default. #197
- Fix can not serialize nested System.IO.DirectoryInfo property. #281
- Fix export of `Like` parameter for `Within` keyword. #279
- **Breaking change**: Added named baselines. This changes how baselines work. #274]
  - Previously, baselines were specified as workspace options.
  - Now, baselines are a separate resource that can be individually used. Additionally:
    - Baselines can be packaged within module.
    - Modules can specify a default baseline in module manifest.
    - Target binding options (`Binding`) are now part of baselines.
  - The previous `baseline` options property has been renamed to `rule`.
  - The previous `configuration` property is now a top level option.
  - See [about_PSRule_Baseline](docs/concepts/PSRule/en-US/about_PSRule_Baseline.md) for more information.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
