### PR TITLE
Expose DependsOn from Get-PSRule #210

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Added dependency `DependsOn` information to results from `Get-PSRule`. [#210](https://github.com/BernieWhite/PSRule/issues/210)
+  - To include dependencies that would normally be filtered out use `-IncludeDependencies`.
+
 ## v0.10.0-B1910025 (pre-release)
 
 - Fix `Get-PSRuleHelp` -Online in constrained language mode. [#296](https://github.com/BernieWhite/PSRule/issues/296)

--- a/docs/commands/PSRule/en-US/Get-PSRule.md
+++ b/docs/commands/PSRule/en-US/Get-PSRule.md
@@ -15,7 +15,8 @@ Get a list of rule definitions.
 
 ```text
 Get-PSRule [-Module <String[]>] [-ListAvailable] [-OutputFormat <OutputFormat>] [[-Path] <String[]>]
- [-Name <String[]>] [-Tag <Hashtable>] [-Option <PSRuleOption>] [-Culture <String>] [<CommonParameters>]
+ [-Name <String[]>] [-Tag <Hashtable>] [-Option <PSRuleOption>] [-Culture <String>] [-IncludeDependencies]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -236,6 +237,24 @@ Type: OutputFormat
 Parameter Sets: (All)
 Aliases:
 Accepted values: None, Wide
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IncludeDependencies
+
+When this switch is specified, dependencies of the rules that meet the `-Name` and `-Tag` filters are included even if they would normally be excluded.
+
+This switch has no affect when getting an unfiltered list of rules.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
 
 Required: False
 Position: Named

--- a/src/PSRule/Common/DictionaryExtensions.cs
+++ b/src/PSRule/Common/DictionaryExtensions.cs
@@ -27,7 +27,7 @@ namespace PSRule
         [DebuggerStepThrough]
         public static bool TryPopValue(this IDictionary<string, object> dictionary, string key, out object value)
         {
-            return dictionary.TryGetValue(key, out value) ? dictionary.Remove(key) : false;
+            return dictionary.TryGetValue(key, out value) && dictionary.Remove(key);
         }
     }
 }

--- a/src/PSRule/Configuration/OutputOption.cs
+++ b/src/PSRule/Configuration/OutputOption.cs
@@ -1,11 +1,12 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
 
 namespace PSRule.Configuration
 {
     /// <summary>
     /// Options for generating and formatting output.
     /// </summary>
-    public sealed class OutputOption
+    public sealed class OutputOption : IEquatable<OutputOption>
     {
         private const ResultFormat DEFAULT_AS = ResultFormat.Detail;
         private const OutputEncoding DEFAULT_ENCODING = OutputEncoding.Default;

--- a/src/PSRule/Host/DependencyGraph.cs
+++ b/src/PSRule/Host/DependencyGraph.cs
@@ -15,7 +15,6 @@ namespace PSRule.Host
         {
             _Targets = new DependencyTarget[targets.Length];
             _Index = new Dictionary<string, DependencyTarget>(targets.Length);
-
             Prepare(targets);
         }
 

--- a/src/PSRule/PSRule.psm1
+++ b/src/PSRule/PSRule.psm1
@@ -529,7 +529,10 @@ function Get-PSRule {
         [PSRule.Configuration.PSRuleOption]$Option,
 
         [Parameter(Mandatory = $False)]
-        [String]$Culture
+        [String]$Culture,
+
+        [Parameter(Mandatory = $False)]
+        [Switch]$IncludeDependencies
     )
 
     begin {
@@ -590,6 +593,11 @@ function Get-PSRule {
         $builder = [PSRule.Pipeline.PipelineBuilder]::Get($sourceFiles, $Option);
         $builder.Name($Name);
         $builder.Tag($Tag);
+
+        if ($IncludeDependencies) {
+            $builder.IncludeDependencies();
+        }
+
         $builder.UseCommandRuntime($PSCmdlet.CommandRuntime);
         $builder.UseExecutionContext($ExecutionContext);
         try {

--- a/src/PSRule/Parser/MarkdownReader.cs
+++ b/src/PSRule/Parser/MarkdownReader.cs
@@ -239,7 +239,7 @@
             _Stream.MarkExtentStart();
 
             // Set the default style
-            var textStyle = MarkdownTokenFlag.None;
+            var textStyle = MarkdownTokenFlags.None;
 
             var startOfLine = _Stream.IsStartOfLine;
 
@@ -260,14 +260,14 @@
 
                 if (_Output.Current != null && _Output.Current.Flag.IsEnding() && !_Output.Current.Flag.ShouldPreserve())
                 {
-                    _Output.Current.Flag |= MarkdownTokenFlag.Preserve;
+                    _Output.Current.Flag |= MarkdownTokenFlags.Preserve;
                 }
             }
 
             // Override line ending if the line was a list item so that the line ending is preserved
             if (_Context == MarkdownReaderMode.List && ending.IsEnding())
             {
-                ending |= MarkdownTokenFlag.Preserve;
+                ending |= MarkdownTokenFlags.Preserve;
             }
 
             // Add the text to the output stream
@@ -279,9 +279,9 @@
             }
         }
 
-        private string UnwrapStyleMarkers(MarkdownStream stream, out MarkdownTokenFlag flag)
+        private string UnwrapStyleMarkers(MarkdownStream stream, out MarkdownTokenFlags flag)
         {
-            flag = MarkdownTokenFlag.None;
+            flag = MarkdownTokenFlags.None;
 
             // Check for style
             var styleChar = stream.Current;
@@ -312,12 +312,12 @@
 
                     if (styleEnding == 1 || styleEnding == 3)
                     {
-                        flag |= MarkdownTokenFlag.Italic;
+                        flag |= MarkdownTokenFlags.Italic;
                     }
 
                     if (styleEnding >= 2)
                     {
-                        flag |= MarkdownTokenFlag.Bold;
+                        flag |= MarkdownTokenFlags.Bold;
                     }
                 }
                 else
@@ -341,7 +341,7 @@
 
                     if (codeEnding == 1)
                     {
-                        flag |= MarkdownTokenFlag.Code;
+                        flag |= MarkdownTokenFlags.Code;
                     }
                 }
                 else
@@ -378,9 +378,9 @@
             return false;
         }
 
-        private MarkdownTokenFlag GetEnding(int lineEndings)
+        private MarkdownTokenFlags GetEnding(int lineEndings)
         {
-            return lineEndings == 0 ? MarkdownTokenFlag.None : (lineEndings == 1) ? MarkdownTokenFlag.LineEnding : MarkdownTokenFlag.LineBreak;
+            return lineEndings == 0 ? MarkdownTokenFlags.None : (lineEndings == 1) ? MarkdownTokenFlags.LineEnding : MarkdownTokenFlags.LineBreak;
         }
 
         /// <summary>

--- a/src/PSRule/Parser/MarkdownToken.cs
+++ b/src/PSRule/Parser/MarkdownToken.cs
@@ -29,7 +29,7 @@ namespace PSRule.Parser
     }
 
     [Flags()]
-    public enum MarkdownTokenFlag
+    public enum MarkdownTokenFlags
     {
         None = 0,
 
@@ -51,19 +51,19 @@ namespace PSRule.Parser
 
     public static class MarkdownTokenFlagExtensions
     {
-        public static bool IsEnding(this MarkdownTokenFlag flag)
+        public static bool IsEnding(this MarkdownTokenFlags flags)
         {
-            return flag.HasFlag(MarkdownTokenFlag.LineEnding) || flag.HasFlag(MarkdownTokenFlag.LineBreak);
+            return flags.HasFlag(MarkdownTokenFlags.LineEnding) || flags.HasFlag(MarkdownTokenFlags.LineBreak);
         }
 
-        public static bool IsLineBreak(this MarkdownTokenFlag flag)
+        public static bool IsLineBreak(this MarkdownTokenFlags flags)
         {
-            return flag.HasFlag(MarkdownTokenFlag.LineBreak);
+            return flags.HasFlag(MarkdownTokenFlags.LineBreak);
         }
 
-        public static bool ShouldPreserve(this MarkdownTokenFlag flag)
+        public static bool ShouldPreserve(this MarkdownTokenFlags flags)
         {
-            return flag.HasFlag(MarkdownTokenFlag.Preserve);
+            return flags.HasFlag(MarkdownTokenFlags.Preserve);
         }
     }
 
@@ -82,6 +82,6 @@ namespace PSRule.Parser
 
         //public MarkdownTokenEnding Ending { get; set; }
 
-        public MarkdownTokenFlag Flag { get; set; }
+        public MarkdownTokenFlags Flag { get; set; }
     }
 }

--- a/src/PSRule/Parser/MarkdownTokenExtensions.cs
+++ b/src/PSRule/Parser/MarkdownTokenExtensions.cs
@@ -4,19 +4,19 @@
     {
         public static bool IsSingleLineEnding(this MarkdownToken token)
         {
-            return token.Flag.HasFlag(MarkdownTokenFlag.LineEnding) ||
+            return token.Flag.HasFlag(MarkdownTokenFlags.LineEnding) ||
                 token.Type == MarkdownTokenType.LineBreak;
         }
 
         public static bool IsPreservableLineEnding(this MarkdownToken token)
         {
-            return (token.Flag.HasFlag(MarkdownTokenFlag.LineEnding) && token.Flag.HasFlag(MarkdownTokenFlag.Preserve)) ||
+            return (token.Flag.HasFlag(MarkdownTokenFlags.LineEnding) && token.Flag.HasFlag(MarkdownTokenFlags.Preserve)) ||
                 token.Type == MarkdownTokenType.LineBreak;
         }
 
         public static bool IsDoubleLineEnding(this MarkdownToken token)
         {
-            return token.Flag.HasFlag(MarkdownTokenFlag.LineBreak) && token.Type != MarkdownTokenType.LineBreak;
+            return token.Flag.HasFlag(MarkdownTokenFlags.LineBreak) && token.Type != MarkdownTokenType.LineBreak;
         }
     }
 }

--- a/src/PSRule/Parser/RuleLexer.cs
+++ b/src/PSRule/Parser/RuleLexer.cs
@@ -235,7 +235,7 @@ namespace PSRule.Parser
                 stream.Next();
             }
 
-            if (stream.EOF && stream.Peak(-1).Flag.HasFlag(MarkdownTokenFlag.Preserve) && stream.Peak(-1).Flag.HasFlag(MarkdownTokenFlag.LineEnding))
+            if (stream.EOF && stream.Peak(-1).Flag.HasFlag(MarkdownTokenFlags.Preserve) && stream.Peak(-1).Flag.HasFlag(MarkdownTokenFlags.LineEnding))
             {
                 AppendEnding(sb, stream.Peak(-1));
             }

--- a/src/PSRule/Parser/TokenStream.cs
+++ b/src/PSRule/Parser/TokenStream.cs
@@ -19,7 +19,7 @@ namespace PSRule.Parser
                 Extent = extent,
                 Text = text,
                 Type = MarkdownTokenType.Header,
-                Flag = lineBreak ? MarkdownTokenFlag.LineBreak : MarkdownTokenFlag.LineEnding | MarkdownTokenFlag.Preserve
+                Flag = lineBreak ? MarkdownTokenFlags.LineBreak : MarkdownTokenFlags.LineEnding | MarkdownTokenFlags.Preserve
             });
         }
 
@@ -44,7 +44,7 @@ namespace PSRule.Parser
                 Meta = meta,
                 Text = text,
                 Type = MarkdownTokenType.FencedBlock,
-                Flag = (lineBreak ? MarkdownTokenFlag.LineBreak : MarkdownTokenFlag.LineEnding) | MarkdownTokenFlag.Preserve
+                Flag = (lineBreak ? MarkdownTokenFlags.LineBreak : MarkdownTokenFlags.LineEnding) | MarkdownTokenFlags.Preserve
             });
         }
 
@@ -61,11 +61,11 @@ namespace PSRule.Parser
 
             for (var i = 0; i < count; i++)
             {
-                stream.Add(new MarkdownToken() { Type = MarkdownTokenType.LineBreak, Flag = MarkdownTokenFlag.LineBreak });
+                stream.Add(new MarkdownToken() { Type = MarkdownTokenType.LineBreak, Flag = MarkdownTokenFlags.LineBreak });
             }
         }
 
-        public static void Text(this TokenStream stream, string text, MarkdownTokenFlag flag = MarkdownTokenFlag.None)
+        public static void Text(this TokenStream stream, string text, MarkdownTokenFlags flag = MarkdownTokenFlags.None)
         {
             if (MergeText(stream.Current, text, flag))
             {
@@ -75,7 +75,7 @@ namespace PSRule.Parser
             stream.Add(new MarkdownToken() { Type = MarkdownTokenType.Text, Text = text, Flag = flag });
         }
 
-        private static bool MergeText(MarkdownToken current, string text, MarkdownTokenFlag flag)
+        private static bool MergeText(MarkdownToken current, string text, MarkdownTokenFlags flag)
         {
             // Only allow merge if the previous token was text
             if (current == null || current.Type != MarkdownTokenType.Text)
@@ -89,23 +89,23 @@ namespace PSRule.Parser
             }
 
             // If the previous token was text, lessen the break but still don't allow merging
-            if (current.Flag.HasFlag(MarkdownTokenFlag.LineBreak) && !current.Flag.ShouldPreserve())
+            if (current.Flag.HasFlag(MarkdownTokenFlags.LineBreak) && !current.Flag.ShouldPreserve())
             {
                 return false;
             }
 
             // Text must have the same flags set
-            if (current.Flag.HasFlag(MarkdownTokenFlag.Italic) != flag.HasFlag(MarkdownTokenFlag.Italic))
+            if (current.Flag.HasFlag(MarkdownTokenFlags.Italic) != flag.HasFlag(MarkdownTokenFlags.Italic))
             {
                 return false;
             }
 
-            if (current.Flag.HasFlag(MarkdownTokenFlag.Bold) != flag.HasFlag(MarkdownTokenFlag.Bold))
+            if (current.Flag.HasFlag(MarkdownTokenFlags.Bold) != flag.HasFlag(MarkdownTokenFlags.Bold))
             {
                 return false;
             }
 
-            if (current.Flag.HasFlag(MarkdownTokenFlag.Code) != flag.HasFlag(MarkdownTokenFlag.Code))
+            if (current.Flag.HasFlag(MarkdownTokenFlags.Code) != flag.HasFlag(MarkdownTokenFlags.Code))
             {
                 return false;
             }
@@ -114,7 +114,7 @@ namespace PSRule.Parser
             {
                 current.Text = string.Concat(current.Text, text);
             }
-            else if (current.Flag == MarkdownTokenFlag.LineEnding)
+            else if (current.Flag == MarkdownTokenFlags.LineEnding)
             {
                 return false;
             }

--- a/src/PSRule/Pipeline/CsvOutputWriter.cs
+++ b/src/PSRule/Pipeline/CsvOutputWriter.cs
@@ -6,7 +6,7 @@ using System.Text;
 
 namespace PSRule.Pipeline
 {
-    internal sealed class CSVSerializer : PipelineWriter
+    internal sealed class CsvOutputWriter : PipelineWriter
     {
         private const char COMMA = ',';
         private const char QUOTE = '"';
@@ -14,7 +14,7 @@ namespace PSRule.Pipeline
         private readonly StringBuilder _Builder;
         private readonly List<InvokeResult> _Result;
 
-        internal CSVSerializer(WriteOutput output)
+        internal CsvOutputWriter(WriteOutput output)
             : base(output)
         {
             _Builder = new StringBuilder();
@@ -34,7 +34,7 @@ namespace PSRule.Pipeline
             base.Write(Serialize(_Result.ToArray()), false);
         }
 
-        internal string Serialize(IEnumerable<InvokeResult> o)
+        private string Serialize(IEnumerable<InvokeResult> o)
         {
             WriteHeader();
             foreach (var result in o)

--- a/src/PSRule/Pipeline/InvokeRulePipeline.cs
+++ b/src/PSRule/Pipeline/InvokeRulePipeline.cs
@@ -25,7 +25,7 @@ namespace PSRule.Pipeline
         protected BindTargetMethod _BindTargetNameHook;
         protected BindTargetMethod _BindTargetTypeHook;
 
-        internal InvokePipelineBuilderBase(Source[] source)
+        protected InvokePipelineBuilderBase(Source[] source)
             : base(source)
         {
             Outcome = RuleOutcome.Processed;
@@ -184,7 +184,6 @@ namespace PSRule.Pipeline
     internal sealed class InvokeRulePipeline : RulePipeline, IPipeline
     {
         private readonly RuleOutcome _Outcome;
-        //private readonly StreamManager _StreamManager;
         private readonly DependencyGraph<RuleBlock> _RuleGraph;
 
         // A per rule summary of rules that have been processed and the outcome
@@ -199,7 +198,6 @@ namespace PSRule.Pipeline
         internal InvokeRulePipeline(PipelineContext context, Source[] source, PipelineReader reader, PipelineWriter writer, RuleOutcome outcome)
             : base(context, source, reader, writer)
         {
-            //_StreamManager = streamManager;
             HostHelper.ImportResource(source: Source, context: context);
             _RuleGraph = HostHelper.GetRuleBlockGraph(source: Source, context: context);
             RuleCount = _RuleGraph.Count;

--- a/src/PSRule/Pipeline/NUnit3OutputWriter.cs
+++ b/src/PSRule/Pipeline/NUnit3OutputWriter.cs
@@ -5,12 +5,12 @@ using System.Text;
 
 namespace PSRule.Pipeline
 {
-    internal sealed class NUnit3Serializer : PipelineWriter
+    internal sealed class NUnit3OutputWriter : PipelineWriter
     {
         private readonly StringBuilder _Builder;
         private readonly List<InvokeResult> _Result;
 
-        internal NUnit3Serializer(WriteOutput output)
+        internal NUnit3OutputWriter(WriteOutput output)
             : base(output)
         {
             _Builder = new StringBuilder();
@@ -30,7 +30,7 @@ namespace PSRule.Pipeline
             base.Write(Serialize(_Result.ToArray()), false);
         }
 
-        internal string Serialize(IEnumerable<InvokeResult> o)
+        private string Serialize(IEnumerable<InvokeResult> o)
         {
             _Builder.Append("<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"no\"?>");
 
@@ -55,7 +55,6 @@ namespace PSRule.Pipeline
             }
 
             _Builder.Append("</test-results>");
-
             return _Builder.ToString();
         }
 

--- a/src/PSRule/Pipeline/PipelineBuilder.cs
+++ b/src/PSRule/Pipeline/PipelineBuilder.cs
@@ -33,7 +33,7 @@ namespace PSRule.Pipeline
             return pipeline;
         }
 
-        public static IPipelineBuilder Get(Source[] source, PSRuleOption option)
+        public static IGetPipelineBuilder Get(Source[] source, PSRuleOption option)
         {
             var pipeline = new GetRulePipelineBuilder(source);
             pipeline.Configure(option);
@@ -194,13 +194,13 @@ namespace PSRule.Pipeline
             switch (Option.Output.Format)
             {
                 case OutputFormat.Csv:
-                    return new CSVSerializer(output);
+                    return new CsvOutputWriter(output);
 
                 case OutputFormat.Json:
                     return new JsonOutputWriter(output);
 
                 case OutputFormat.NUnit3:
-                    return new NUnit3Serializer(output);
+                    return new NUnit3OutputWriter(output);
 
                 case OutputFormat.Yaml:
                     return new YamlOutputWriter(output);

--- a/src/PSRule/Pipeline/PipelineWriter.cs
+++ b/src/PSRule/Pipeline/PipelineWriter.cs
@@ -10,7 +10,7 @@ namespace PSRule.Pipeline
     {
         private readonly WriteOutput _Output;
 
-        internal PipelineWriter(WriteOutput output)
+        protected PipelineWriter(WriteOutput output)
         {
             _Output = output;
         }

--- a/src/PSRule/Pipeline/RulePipeline.cs
+++ b/src/PSRule/Pipeline/RulePipeline.cs
@@ -14,7 +14,7 @@ namespace PSRule.Pipeline
         // Track whether Dispose has been called.
         private bool _Disposed = false;
 
-        internal RulePipeline(PipelineContext context, Source[] source, PipelineReader reader, PipelineWriter writer)
+        protected RulePipeline(PipelineContext context, Source[] source, PipelineReader reader, PipelineWriter writer)
         {
             Context = context;
             Source = source;

--- a/src/PSRule/Rules/Rule.cs
+++ b/src/PSRule/Rules/Rule.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using PSRule.Host;
 using System.ComponentModel;
 using YamlDotNet.Serialization;
 
@@ -8,7 +9,7 @@ namespace PSRule.Rules
     /// Define a single rule.
     /// </summary>
     [JsonObject]
-    public sealed class Rule
+    public sealed class Rule : IDependencyTarget
     {
         /// <summary>
         /// A unique identifier for the rule.
@@ -25,14 +26,16 @@ namespace PSRule.Rules
         /// <summary>
         /// The script file path where the rule is defined.
         /// </summary>
-        [JsonProperty(PropertyName = "sourcePath")]
-        public string SourcePath { get; set; }
+        [JsonIgnore]
+        [YamlIgnore]
+        public string SourcePath => Source.Path;
 
         /// <summary>
         /// The name of the module where the rule is defined, or null if the rule is not defined in a module.
         /// </summary>
-        [JsonProperty(PropertyName = "moduleName")]
-        public string ModuleName { get; set; }
+        [JsonIgnore]
+        [YamlIgnore]
+        public string ModuleName => Source.ModuleName;
 
         /// <summary>
         /// A human readable block of text, used to identify the purpose of the rule.
@@ -56,5 +59,15 @@ namespace PSRule.Rules
         [JsonProperty(PropertyName = "info")]
         [DefaultValue(null)]
         public RuleHelpInfo Info { get; set; }
+
+        [JsonProperty(PropertyName = "source")]
+        [DefaultValue(null)]
+        public SourceFile Source { get; set; }
+
+        /// <summary>
+        /// Other rules that must completed successfully before calling this rule.
+        /// </summary>
+        [JsonProperty(PropertyName = "dependsOn")]
+        public string[] DependsOn { get; set; }
     }
 }

--- a/src/PSRule/Rules/RuleBlock.cs
+++ b/src/PSRule/Rules/RuleBlock.cs
@@ -50,7 +50,7 @@ namespace PSRule.Rules
         public readonly PowerShell Condition;
 
         /// <summary>
-        /// Other deployments that must completed successfully before calling this rule.
+        /// Other rules that must completed successfully before calling this rule.
         /// </summary>
         public readonly string[] DependsOn;
 

--- a/tests/PSRule.Tests/PSRule.Common.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Common.Tests.ps1
@@ -1166,6 +1166,24 @@ Describe 'Get-PSRule' -Tag 'Get-PSRule','Common' {
         }
     }
 
+    Context 'Using -IncludeDependencies' {
+        It 'Returns rules' {
+            # Get a list of rules without dependencies
+            $result = @(Get-PSRule -Path $ruleFilePath -Name 'FromFile4');
+            $result | Should -Not -BeNullOrEmpty;
+            $result.Length | Should -Be 1;
+            $result[0].DependsOn | Should -BeIn 'FromFile3';
+
+            # Get a list of rules with dependencies
+            $result = @(Get-PSRule -Path $ruleFilePath -Name 'FromFile4' -IncludeDependencies);
+            $result | Should -Not -BeNullOrEmpty;
+            $result.Length | Should -Be 2;
+            $result[0].RuleName | Should -Be 'FromFile3';
+            $result[1].RuleName | Should -Be 'FromFile4';
+            $result[1].DependsOn | Should -BeIn 'FromFile3';
+        }
+    }
+
     # Context 'Using -OutputFormat' {
     #     It 'Yaml' {
     #         $result = Get-PSRule -Path $ruleFilePath -Name 'FromFile1' -OutputFormat Yaml;


### PR DESCRIPTION
## PR Summary

- Added dependency `DependsOn` information to results from `Get-PSRule`. #210
  - To include dependencies that would normally be filtered out use `-IncludeDependencies`.

Fixes #210 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/BernieWhite/PSRule/blob/master/CHANGELOG.md) has been updated with change under unreleased section
