### PR TITLE
Add markdown format and source info #301 #302

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -33,6 +33,9 @@
         "Kubernetes",
         "cmdlet",
         "cmdlets",
+        "deserialize",
+        "deserialized",
+        "deserializes",
         "hashtable"
     ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - Added dependency `DependsOn` information to results from `Get-PSRule`. [#210](https://github.com/BernieWhite/PSRule/issues/210)
   - To include dependencies that would normally be filtered out use `-IncludeDependencies`.
+- Added input format for reading markdown front matter. [#301](https://github.com/BernieWhite/PSRule/issues/301)
+  - Markdown front matter is deserialized and evaluated as an object.
+- Added source note properties to input objects read from disk with `-InputPath`. [#302](https://github.com/BernieWhite/PSRule/issues/302)
 
 ## v0.10.0-B1910025 (pre-release)
 

--- a/docs/commands/PSRule/en-US/Assert-PSRule.md
+++ b/docs/commands/PSRule/en-US/Assert-PSRule.md
@@ -141,14 +141,19 @@ Accept wildcard characters: False
 
 Configures the input format for when a string is passed in as a target object.
 
-- When the `-InputObject` parameter or pipeline input is used, strings are treated as plain text by default. When this option is used and set to either `Yaml` or `Json`, strings are read as YAML or JSON and are converted to an object.
-- When the `-InputPath` parameter is used with a file path or URL, by default the file extension (either `.yaml`, `.yml` or `.json`) will be used to automatically detect the format as YAML or JSON.
+When the `-InputObject` parameter or pipeline input is used, strings are treated as plain text by default.
+Set this option to either `Yaml`, `Json` or `Markdown` to have PSRule deserialize the object.
+
+When the `-InputPath` parameter is used with a file path or URL.
+If the `Detect` format is used, the file extension (either `.yaml`, `.yml`, `.json` or `.md`) will be used to automatically detect the format as YAML, JSON or Markdown.
+
+This parameter takes precedence over the `Input.Format` option if set.
 
 ```yaml
 Type: InputFormat
 Parameter Sets: (All)
 Aliases:
-Accepted values: None, Yaml, Json, Detect
+Accepted values: None, Yaml, Json, Markdown, Detect
 
 Required: False
 Position: Named

--- a/docs/commands/PSRule/en-US/Invoke-PSRule.md
+++ b/docs/commands/PSRule/en-US/Invoke-PSRule.md
@@ -264,14 +264,19 @@ Accept wildcard characters: False
 
 Configures the input format for when a string is passed in as a target object.
 
-- When the `-InputObject` parameter or pipeline input is used, strings are treated as plain text by default. When this option is used and set to either `Yaml` or `Json`, strings are read as YAML or JSON and are converted to an object.
-- When the `-InputPath` parameter is used with a file path or URL, by default the file extension (either `.yaml`, `.yml` or `.json`) will be used to automatically detect the format as YAML or JSON.
+When the `-InputObject` parameter or pipeline input is used, strings are treated as plain text by default.
+Set this option to either `Yaml`, `Json` or `Markdown` to have PSRule deserialize the object.
+
+When the `-InputPath` parameter is used with a file path or URL.
+If the `Detect` format is used, the file extension (either `.yaml`, `.yml`, `.json` or `.md`) will be used to automatically detect the format as YAML, JSON or Markdown.
+
+This parameter takes precedence over the `Input.Format` option if set.
 
 ```yaml
 Type: InputFormat
 Parameter Sets: (All)
 Aliases:
-Accepted values: None, Yaml, Json, Detect
+Accepted values: None, Yaml, Json, Markdown, Detect
 
 Required: False
 Position: Named

--- a/docs/commands/PSRule/en-US/Test-PSRuleTarget.md
+++ b/docs/commands/PSRule/en-US/Test-PSRuleTarget.md
@@ -154,14 +154,19 @@ Accept wildcard characters: False
 
 Configures the input format for when a string is passed in as a target object.
 
-- When the `-InputObject` parameter or pipeline input is used, strings are treated as plain text by default. When this option is used and set to either `Yaml` or `Json`, strings are read as YAML or JSON and are converted to an object.
-- When the `-InputPath` parameter is used with a file path or URL, by default the file extension (either `.yaml`, `.yml` or `.json`) will be used to automatically detect the format as YAML or JSON.
+When the `-InputObject` parameter or pipeline input is used, strings are treated as plain text by default.
+Set this option to either `Yaml`, `Json` or `Markdown` to have PSRule deserialize the object.
+
+When the `-InputPath` parameter is used with a file path or URL.
+If the `Detect` format is used, the file extension (either `.yaml`, `.yml`, `.json` or `.md`) will be used to automatically detect the format as YAML, JSON or Markdown.
+
+This parameter takes precedence over the `Input.Format` option if set.
 
 ```yaml
 Type: InputFormat
 Parameter Sets: (All)
 Aliases:
-Accepted values: None, Yaml, Json, Detect
+Accepted values: None, Yaml, Json, Markdown, Detect
 
 Required: False
 Position: Named

--- a/docs/concepts/PSRule/en-US/about_PSRule_Options.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Options.md
@@ -391,18 +391,29 @@ execution:
 
 Configures the input format for when a string is passed in as a target object.
 
-Using this option with `Invoke-PSRule` or `Test-PSRuleTarget`:
+Use this option with `Assert-PSRule`, `Invoke-PSRule` or `Test-PSRuleTarget`.
 
-- When the `-InputObject` parameter or pipeline input is used, strings are treated as plain text by default. When this option is used and set to either `Yaml` or `Json`, strings are read as YAML or JSON and are converted to an object.
-- When the `-InputPath` parameter is used with a file path or URL, by default the file extension (either `.yaml`, `.yml` or `.json`) will be used to automatically detect the format as YAML or JSON.
-- The `-Format` parameter will override any value set in configuration.
+When the `-InputObject` parameter or pipeline input is used, strings are treated as plain text by default.
+Set this option to either `Yaml`, `Json` or `Markdown` to have PSRule deserialize the object.
+
+When the `-InputPath` parameter is used with a file path or URL.
+If the `Detect` format is used, the file extension (either `.yaml`, `.yml`, `.json` or `.md`) will be used to automatically detect the format as YAML, JSON or Markdown.
+
+The `-Format` parameter will override any value set in configuration.
 
 The following formats are available:
 
 - None - Treat strings as plain text.
 - Yaml - Treat strings as one or more YAML objects.
 - Json - Treat strings as one or more JSON objects.
-- Detect - Detect format based on file extension. Detection only applies when used with the `-InputPath` parameter. In all other cases, `Detect` is the same as `None`. This is the default configuration.
+- Markdown - Treat strings as a markdown object.
+- Detect - Detect format based on file extension.
+
+Detection only applies when used with the `-InputPath` parameter.
+In all other cases, `Detect` is the same as `None`. This is the default configuration.
+
+The `Markdown` format does not parse the whole markdown document.
+Specifically this format deserializes YAML front matter from the top of the document if any exists.
 
 This option can be specified using:
 

--- a/src/PSRule/Common/PSObjectExtensions.cs
+++ b/src/PSRule/Common/PSObjectExtensions.cs
@@ -10,9 +10,7 @@ namespace PSRule
         public static T PropertyValue<T>(this PSObject o, string propertyName)
         {
             if (typeof(T).IsValueType)
-            {
                 return (T)Convert.ChangeType(o.Properties[propertyName].Value, typeof(T));
-            }
 
             return (T)o.Properties[propertyName].Value;
         }
@@ -20,16 +18,11 @@ namespace PSRule
         public static string ValueAsString(this PSObject o, string propertyName, bool caseSensitive)
         {
             var p = o.Properties[propertyName];
-
             if (p == null)
-            {
                 return null;
-            }
 
             if (caseSensitive && !StringComparer.Ordinal.Equals(p.Name, propertyName))
-            {
                 return null;
-            }
 
             return p.Value.ToString();
         }
@@ -38,19 +31,19 @@ namespace PSRule
         {
             value = null;
             var p = o.Properties[propertyName];
-
             if (p == null)
-            {
                 return false;
-            }
 
             if (caseSensitive && !StringComparer.Ordinal.Equals(p.Name, propertyName))
-            {
                 return false;
-            }
 
             value = p.Value;
             return true;
+        }
+
+        public static bool HasProperty(this PSObject o, string propertyName)
+        {
+            return o.Properties[propertyName] != null;
         }
 
         public static string ToJson(this PSObject o)

--- a/src/PSRule/Configuration/InputFormat.cs
+++ b/src/PSRule/Configuration/InputFormat.cs
@@ -15,6 +15,8 @@ namespace PSRule.Configuration
 
         Json = 2,
 
+        Markdown = 3,
+
         Detect = 255
     }
 }

--- a/src/PSRule/PSRule.psm1
+++ b/src/PSRule/PSRule.psm1
@@ -44,7 +44,7 @@ function Invoke-PSRule {
         [PSRule.Configuration.ResultFormat]$As = [PSRule.Configuration.ResultFormat]::Detail,
 
         [Parameter(Mandatory = $False)]
-        [ValidateSet('None', 'Yaml', 'Json', 'Detect')]
+        [ValidateSet('None', 'Yaml', 'Json', 'Markdown', 'Detect')]
         [PSRule.Configuration.InputFormat]$Format = [PSRule.Configuration.InputFormat]::Detect,
 
         [Parameter(Mandatory = $False)]
@@ -206,7 +206,7 @@ function Test-PSRuleTarget {
         [String[]]$Module,
 
         [Parameter(Mandatory = $False)]
-        [ValidateSet('None', 'Yaml', 'Json', 'Detect')]
+        [ValidateSet('None', 'Yaml', 'Json', 'Markdown', 'Detect')]
         [PSRule.Configuration.InputFormat]$Format,
 
         # A list of paths to check for rule definitions
@@ -347,7 +347,7 @@ function Assert-PSRule {
         [String[]]$Module,
 
         [Parameter(Mandatory = $False)]
-        [ValidateSet('None', 'Yaml', 'Json', 'Detect')]
+        [ValidateSet('None', 'Yaml', 'Json', 'Markdown', 'Detect')]
         [PSRule.Configuration.InputFormat]$Format = [PSRule.Configuration.InputFormat]::Detect,
 
         [Parameter(Mandatory = $False)]
@@ -883,7 +883,7 @@ function New-PSRuleOption {
 
         # Sets the Input.Format option
         [Parameter(Mandatory = $False)]
-        [ValidateSet('None', 'Yaml', 'Json', 'Detect')]
+        [ValidateSet('None', 'Yaml', 'Json', 'Markdown', 'Detect')]
         [Alias('InputFormat')]
         [PSRule.Configuration.InputFormat]$Format = 'Detect',
 
@@ -1049,7 +1049,7 @@ function Set-PSRuleOption {
 
         # Sets the Input.Format option
         [Parameter(Mandatory = $False)]
-        [ValidateSet('None', 'Yaml', 'Json', 'Detect')]
+        [ValidateSet('None', 'Yaml', 'Json', 'Markdown', 'Detect')]
         [Alias('InputFormat')]
         [PSRule.Configuration.InputFormat]$Format = 'Detect',
 
@@ -1610,7 +1610,7 @@ function SetOptions {
 
         # Sets the Input.Format option
         [Parameter(Mandatory = $False)]
-        [ValidateSet('None', 'Yaml', 'Json', 'Detect')]
+        [ValidateSet('None', 'Yaml', 'Json', 'Markdown', 'Detect')]
         [Alias('InputFormat')]
         [PSRule.Configuration.InputFormat]$Format = 'Detect',
 

--- a/src/PSRule/Parser/MarkdownConvert.cs
+++ b/src/PSRule/Parser/MarkdownConvert.cs
@@ -1,0 +1,40 @@
+﻿using System.Management.Automation;
+
+namespace PSRule.Parser
+{
+    internal static class MarkdownConvert
+    {
+        private const char Dash = '-';
+        private const string TripleDash = "---";
+
+        public static PSObject[] DeserializeObject(string markdown)
+        {
+            var result = YamlHeader(markdown);
+            return result == null ? new PSObject[] { } : new PSObject[] { result };
+        }
+
+        private static PSObject YamlHeader(string markdown)
+        {
+            var stream = new MarkdownStream(markdown);
+
+            if (stream.EOF || stream.Line > 1 || stream.Current != Dash)
+                return null;
+
+            // Check if the line is just dashes indicating start of yaml header
+            if (!stream.PeakLine(Dash, out int count) || count < 2)
+                return null;
+
+            stream.Skip(count + 1);
+            stream.SkipLineEnding();
+
+            var yaml = stream.CaptureUntil(TripleDash, onNewLine: true).Trim();
+            var d = new YamlDotNet.Serialization.DeserializerBuilder()
+                .IgnoreUnmatchedProperties()
+                .WithTypeConverter(new PSObjectYamlTypeConverter())
+                .WithNodeTypeResolver(new PSObjectYamlTypeResolver())
+                .Build();
+
+            return d.Deserialize<PSObject>(yaml);
+        }
+    }
+}

--- a/src/PSRule/Parser/MarkdownReader.cs
+++ b/src/PSRule/Parser/MarkdownReader.cs
@@ -62,9 +62,7 @@
             YamlHeader();
 
             if (_YamlHeaderOnly)
-            {
                 return _Output;
-            }
 
             while (!_Stream.EOF)
             {
@@ -75,9 +73,7 @@
                     LineBreak();
 
                 if (!processed)
-                {
                     Text();
-                }
             }
 
             return _Output;
@@ -86,15 +82,11 @@
         private void YamlHeader()
         {
             if (_Stream.EOF || _Stream.Line > 1 || _Stream.Current != Dash)
-            {
                 return;
-            }
 
             // Check if the line is just dashes indicating start of yaml header
             if (!_Stream.PeakLine(Dash, out int count) || count < 2)
-            {
                 return;
-            }
 
             _Stream.Skip(count + 1);
             _Stream.SkipLineEnding();
@@ -102,7 +94,6 @@
             while (!_Stream.EOF && !_Stream.IsSequence(TripleDash, onNewLine: true))
             {
                 var key = _Stream.CaptureUntil(YamlHeaderStopCharacters).Trim();
-
                 _Stream.SkipWhitespace();
 
                 if (!string.IsNullOrEmpty(key) && _Stream.Skip(Colon))
@@ -111,7 +102,6 @@
 
                     var value = _Stream.CaptureUntil(LineEndingCharacters).TrimEnd();
                     _Stream.SkipLineEnding();
-
                     _Output.YamlKeyValue(key, value);
                 }
                 else
@@ -119,7 +109,6 @@
                     _Stream.Next();
                 }
             }
-
             _Stream.Skip(TripleDash);
             _Stream.SkipLineEnding();
         }
@@ -127,15 +116,11 @@
         private bool UnderlineHeader()
         {
             if ((_Stream.Current != Dash && _Stream.Current != EqualSign) || !_Stream.IsStartOfLine)
-            {
                 return false;
-            }
 
             // Check the line is made up of the same characters
             if (!_Stream.PeakLine(_Stream.Current, out int count))
-            {
                 return false;
-            }
 
             char currentChar = _Stream.Current;
 
@@ -145,12 +130,10 @@
                 var previousToken = _Output.Pop();
 
                 _Stream.Skip(count + 1);
-
                 _Output.Header(currentChar == EqualSign ? 1 : 2, previousToken.Text, null, lineBreak: (_Stream.SkipLineEnding(max: 0) > 1));
 
                 return true;
             }
-
             return false;
         }
 
@@ -160,9 +143,7 @@
         private bool HashHeader()
         {
             if (_Stream.Current != Hash || !_Stream.IsStartOfLine)
-            {
                 return false;
-            }
 
             _Stream.MarkExtentStart();
             _Stream.Next();
@@ -173,11 +154,9 @@
             // Capture to the end of the line
             _Stream.SkipWhitespace();
             var text = _Stream.CaptureLine();
-
             var extent = _Stream.GetExtent();
 
             _Output.Header(headerDepth, text, extent, lineBreak: (_Stream.SkipLineEnding(max: 0) > 1));
-
             return true;
         }
 
@@ -208,29 +187,23 @@
 
             // Write code fence beginning
             _Output.FencedBlock(info, text, null, lineBreak: _Stream.SkipLineEnding(max: 0) > 1);
-
             return true;
         }
 
         private bool LineBreak()
         {
             if (_Stream.Current != '\r' && _Stream.Current != '\n')
-            {
                 return false;
-            }
 
             if (_Stream.IsSequence("\r\n"))
             {
                 var breakCount = _Stream.SkipLineEnding(max: 0, ignoreEscaping: _PreserveFormatting);
 
                 if (_PreserveFormatting)
-                {
                     _Output.LineBreak(count: breakCount);
-                }
 
                 return true;
             }
-
             return false;
         }
 
@@ -250,33 +223,25 @@
             var ending = GetEnding(_Stream.SkipLineEnding(max: 2));
 
             if (string.IsNullOrWhiteSpace(text) && !_PreserveFormatting)
-            {
                 return;
-            }
 
             if (_Context != MarkdownReaderMode.List && startOfLine && IsList(text))
             {
                 _Context = MarkdownReaderMode.List;
 
                 if (_Output.Current != null && _Output.Current.Flag.IsEnding() && !_Output.Current.Flag.ShouldPreserve())
-                {
                     _Output.Current.Flag |= MarkdownTokenFlags.Preserve;
-                }
             }
 
             // Override line ending if the line was a list item so that the line ending is preserved
             if (_Context == MarkdownReaderMode.List && ending.IsEnding())
-            {
                 ending |= MarkdownTokenFlags.Preserve;
-            }
 
             // Add the text to the output stream
             _Output.Text(text, flag: textStyle | ending);
 
             if (_Context == MarkdownReaderMode.List && ending.IsEnding())
-            {
                 _Context = MarkdownReaderMode.None;
-            }
         }
 
         private string UnwrapStyleMarkers(MarkdownStream stream, out MarkdownTokenFlags flag)
@@ -300,25 +265,17 @@
 
                     // Add back underscores within text
                     if (styleChar == Underscore && stylePrevious != Whitespace)
-                    {
                         return Pad(text, styleChar, left: styleCount, right: styleCount);
-                    }
 
                     // Add back asterixes/underscores that are part of text
                     if (styleEnding < styleCount)
-                    {
                         text = Pad(text, styleChar, left: styleCount - styleEnding);
-                    }
 
                     if (styleEnding == 1 || styleEnding == 3)
-                    {
                         flag |= MarkdownTokenFlags.Italic;
-                    }
 
                     if (styleEnding >= 2)
-                    {
                         flag |= MarkdownTokenFlags.Bold;
-                    }
                 }
                 else
                 {
@@ -335,14 +292,10 @@
 
                     // Add back backticks that are part of text
                     if (codeEnding < codeCount)
-                    {
                         text = Pad(text, styleChar, left: codeCount - codeEnding);
-                    }
 
                     if (codeEnding == 1)
-                    {
                         flag |= MarkdownTokenFlags.Code;
-                    }
                 }
                 else
                 {
@@ -350,7 +303,6 @@
                     text = Pad(text, styleChar, left: codeCount);
                 }
             }
-
             return text;
         }
 
@@ -364,16 +316,12 @@
             var clean = text.Trim();
 
             if (string.IsNullOrEmpty(clean))
-            {
                 return false;
-            }
 
             var firstChar = clean[0];
 
             if (firstChar == Dash || firstChar == Asterix)
-            {
                 return true;
-            }
 
             return false;
         }
@@ -389,9 +337,7 @@
         private bool Link()
         {
             if (_Stream.Current != BracketOpen || _Stream.IsEscaped)
-            {
                 return false;
-            }
 
             _Stream.MarkExtentStart();
             _Stream.Checkpoint();
@@ -470,7 +416,6 @@
             }
 
             var extent = _Stream.GetExtent();
-
             return true;
         }
 

--- a/src/PSRule/Pipeline/InvokeRulePipeline.cs
+++ b/src/PSRule/Pipeline/InvokeRulePipeline.cs
@@ -160,6 +160,13 @@ namespace PSRule.Pipeline
                     return PipelineReceiverActions.ConvertFromJson(sourceObject, next);
                 });
             }
+            else if (Option.Input.Format == InputFormat.Markdown)
+            {
+                AddVisitTargetObjectAction((sourceObject, next) =>
+                {
+                    return PipelineReceiverActions.ConvertFromMarkdown(sourceObject, next);
+                });
+            }
             else if (Option.Input.Format == InputFormat.Detect && _InputPath != null)
             {
                 AddVisitTargetObjectAction((sourceObject, next) =>

--- a/src/PSRule/Pipeline/PipelineReciever.cs
+++ b/src/PSRule/Pipeline/PipelineReciever.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using PSRule.Parser;
 using PSRule.Runtime;
 using System;
 using System.Collections;
@@ -15,10 +16,31 @@ namespace PSRule.Pipeline
     public delegate IEnumerable<PSObject> VisitTargetObject(PSObject sourceObject);
     public delegate IEnumerable<PSObject> VisitTargetObjectAction(PSObject sourceObject, VisitTargetObject next);
 
-    //public delegate void Visit
-
     public static class PipelineReceiverActions
     {
+        private const string PropertyName_PSPath = "PSPath";
+        private const string PropertyName_PSParentPath = "PSParentPath";
+        private const string PropertyName_PSChildName = "PSChildName";
+
+        private sealed class PSSourceInfo
+        {
+            public readonly string PSPath;
+            public readonly string PSChildName;
+            public readonly string PSParentPath;
+
+            public PSSourceInfo(FileInfo info)
+            {
+                PSPath = info.FullName;
+                PSChildName = info.Name;
+                PSParentPath = info.DirectoryName;
+            }
+
+            public PSSourceInfo(Uri uri)
+            {
+                PSPath = uri.AbsoluteUri;
+            }
+        }
+
         public static IEnumerable<PSObject> PassThru(PSObject targetObject)
         {
             yield return targetObject;
@@ -49,77 +71,31 @@ namespace PSRule.Pipeline
             {
                 return ConvertFromYaml(sourceObject: sourceObject, next: next);
             }
-
+            // Handle Markdown
+            else if (pathExtension == ".md")
+            {
+                return ConvertFromMarkdown(sourceObject: sourceObject, next: next);
+            }
             return new PSObject[] { sourceObject };
         }
 
         public static IEnumerable<PSObject> ConvertFromJson(PSObject sourceObject, VisitTargetObject next)
         {
-            // Only attempt to deserialize if the input is a string or a file
+            // Only attempt to deserialize if the input is a string, file or URI
             if (!IsAcceptedType(sourceObject: sourceObject))
-            {
                 return new PSObject[] { sourceObject };
-            }
 
-            var json = string.Empty;
-
-            if (sourceObject.BaseObject is string)
-            {
-                json = sourceObject.BaseObject.ToString();
-            }
-            else if (sourceObject.BaseObject is FileInfo)
-            {
-                var fileInfo = sourceObject.BaseObject as FileInfo;
-                using (var reader = new StreamReader(fileInfo.FullName))
-                {
-                    json = reader.ReadToEnd();
-                }
-            }
-            else
-            {
-                var uri = sourceObject.BaseObject as Uri;
-                using (var webClient = new WebClient())
-                {
-                    json = webClient.DownloadString(uri);
-                }
-            }
-
+            var json = ReadAsString(sourceObject, out PSSourceInfo source);
             var value = JsonConvert.DeserializeObject<PSObject[]>(json, new PSObjectArrayJsonConverter());
-
-            if (value == null)
-            {
-                return null;
-            }
-
-            var result = new List<PSObject>();
-
-            foreach (var item in value)
-            {
-                var items = next(item);
-
-                if (items == null)
-                {
-                    continue;
-                }
-
-                result.AddRange(items);
-            }
-
-            if (result.Count == 0)
-            {
-                return null;
-            }
-
-            return result.ToArray();
+            NoteSource(value, source);
+            return VisitItems(value, next);
         }
 
         public static IEnumerable<PSObject> ConvertFromYaml(PSObject sourceObject, VisitTargetObject next)
         {
-            // Only attempt to deserialize if the input is a string or a file
+            // Only attempt to deserialize if the input is a string, file or URI
             if (!IsAcceptedType(sourceObject: sourceObject))
-            {
                 return new PSObject[] { sourceObject };
-            }
 
             var d = new DeserializerBuilder()
                 .IgnoreUnmatchedProperties()
@@ -127,57 +103,43 @@ namespace PSRule.Pipeline
                 .WithNodeTypeResolver(new PSObjectYamlTypeResolver())
                 .Build();
 
-            TextReader reader = null;
-
-            if (sourceObject.BaseObject is string)
-            {
-                reader = new StringReader(sourceObject.BaseObject.ToString());
-            }
-            else if (sourceObject.BaseObject is FileInfo)
-            {
-                var fileInfo = sourceObject.BaseObject as FileInfo;
-                reader = new StreamReader(fileInfo.FullName);
-            }
-            else
-            {
-                var uri = sourceObject.BaseObject as Uri;
-                using (var webClient = new WebClient())
-                {
-                    reader = new StringReader(webClient.DownloadString(uri));
-                }
-            }
-
+            var reader = ReadAsReader(sourceObject, out PSSourceInfo source);
             var parser = new YamlDotNet.Core.Parser(reader);
-
             parser.Expect<StreamStart>();
 
             var result = new List<PSObject>();
-
             while (parser.Accept<DocumentStart>())
             {
                 var item = d.Deserialize<PSObject>(parser: parser);
 
                 if (item == null)
-                {
                     continue;
-                }
 
+                NoteSource(item, source);
                 var items = next(item);
 
                 if (items == null)
-                {
                     continue;
-                }
 
                 result.AddRange(items);
             }
 
             if (result.Count == 0)
-            {
                 return null;
-            }
 
             return result.ToArray();
+        }
+
+        public static IEnumerable<PSObject> ConvertFromMarkdown(PSObject sourceObject, VisitTargetObject next)
+        {
+            // Only attempt to deserialize if the input is a string or a file
+            if (!IsAcceptedType(sourceObject: sourceObject))
+                return new PSObject[] { sourceObject };
+
+            var markdown = ReadAsString(sourceObject, out PSSourceInfo source);
+            var value = MarkdownConvert.DeserializeObject(markdown);
+            NoteSource(value, source);
+            return VisitItems(value, next);
         }
 
         public static IEnumerable<PSObject> ReadObjectPath(PSObject sourceObject, VisitTargetObject source, string objectPath, bool caseSensitive)
@@ -209,6 +171,101 @@ namespace PSRule.Pipeline
         private static bool IsAcceptedType(PSObject sourceObject)
         {
             return sourceObject.BaseObject is string || sourceObject.BaseObject is FileInfo || sourceObject.BaseObject is Uri;
+        }
+
+        private static string ReadAsString(PSObject sourceObject, out PSSourceInfo sourceInfo)
+        {
+            sourceInfo = null;
+            if (sourceObject.BaseObject is string)
+            {
+                return sourceObject.BaseObject.ToString();
+            }
+            else if (sourceObject.BaseObject is FileInfo fileInfo)
+            {
+                sourceInfo = new PSSourceInfo(fileInfo);
+                using (var reader = new StreamReader(fileInfo.FullName))
+                {
+                    return reader.ReadToEnd();
+                }
+            }
+            else
+            {
+                var uri = sourceObject.BaseObject as Uri;
+                sourceInfo = new PSSourceInfo(uri); 
+                using (var webClient = new WebClient())
+                {
+                    return webClient.DownloadString(uri);
+                }
+            }
+        }
+
+        private static TextReader ReadAsReader(PSObject sourceObject, out PSSourceInfo sourceInfo)
+        {
+            sourceInfo = null;
+            if (sourceObject.BaseObject is string)
+            {
+                return new StringReader(sourceObject.BaseObject.ToString());
+            }
+            else if (sourceObject.BaseObject is FileInfo fileInfo)
+            {
+                sourceInfo = new PSSourceInfo(fileInfo);
+                return new StreamReader(fileInfo.FullName);
+            }
+            else
+            {
+                var uri = sourceObject.BaseObject as Uri;
+                sourceInfo = new PSSourceInfo(uri);
+                using (var webClient = new WebClient())
+                {
+                    return new StringReader(webClient.DownloadString(uri));
+                }
+            }
+        }
+
+        private static IEnumerable<PSObject> VisitItems(PSObject[] value, VisitTargetObject next)
+        {
+            if (value == null)
+                return null;
+
+            var result = new List<PSObject>();
+
+            foreach (var item in value)
+            {
+                var items = next(item);
+                if (items == null)
+                    continue;
+
+                result.AddRange(items);
+            }
+
+            if (result.Count == 0)
+                return null;
+
+            return result.ToArray();
+        }
+
+        private static void NoteSource(PSObject[] value, PSSourceInfo source)
+        {
+            if (value == null || value.Length == 0 || source == null)
+                return;
+
+            for (var i = 0; i < value.Length; i++)
+                NoteSource(value[i], source);
+        }
+
+        private static void NoteSource(PSObject value, PSSourceInfo source)
+        {
+            if (value == null || source == null)
+                return;
+
+            if (!value.HasProperty(PropertyName_PSPath))
+                value.Properties.Add(new PSNoteProperty(PropertyName_PSPath, source.PSPath));
+
+            if (!value.HasProperty(PropertyName_PSParentPath))
+                value.Properties.Add(new PSNoteProperty(PropertyName_PSParentPath, source.PSParentPath));
+
+            if (!value.HasProperty(PropertyName_PSChildName))
+                value.Properties.Add(new PSNoteProperty(PropertyName_PSChildName, source.PSChildName));
         }
     }
 }

--- a/src/PSRule/Rules/ResourceRef.cs
+++ b/src/PSRule/Rules/ResourceRef.cs
@@ -5,7 +5,7 @@
         public readonly string Id;
         public readonly ResourceKind Kind;
 
-        public ResourceRef(string id, ResourceKind kind)
+        protected ResourceRef(string id, ResourceKind kind)
         {
             Kind = kind;
             Id = id;

--- a/tests/PSRule.Tests/ObjectFromFile.md
+++ b/tests/PSRule.Tests/ObjectFromFile.md
@@ -1,0 +1,15 @@
+---
+targetName: TestObject1
+spec:
+  properties:
+    value1: 1
+    kind: Test
+    array:
+    - id: 1
+    - id: 2
+    array2:
+    - "1"
+    - "2"
+    - "3"
+---
+

--- a/tests/PSRule.Tests/PSRule.Common.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Common.Tests.ps1
@@ -296,7 +296,7 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
             $result | Should -Not -BeNullOrEmpty;
             $result.Count | Should -Be 2;
             $result | Should -BeOfType PSRule.Rules.RuleSummaryRecord;
-            $result.RuleName | Should -BeIn 'FromFile2', 'FromFile3'
+            $result.RuleName | Should -BeIn 'FromFile2', 'FromFile3';
             $result.Tag.category | Should -BeIn 'group1';
         }
     }
@@ -308,7 +308,7 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
             $result | Should -Not -BeNullOrEmpty;
             $result.Length | Should -Be 2;
             $result | Should -BeOfType PSRule.Rules.RuleRecord;
-            $result.TargetName | Should -BeIn 'TestObject1', 'TestObject2'
+            $result.TargetName | Should -BeIn 'TestObject1', 'TestObject2';
         }
 
         It 'Yaml FileInfo' {
@@ -317,7 +317,7 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
             $result | Should -Not -BeNullOrEmpty;
             $result.Length | Should -Be 2;
             $result | Should -BeOfType PSRule.Rules.RuleRecord;
-            $result.TargetName | Should -BeIn 'TestObject1', 'TestObject2'
+            $result.TargetName | Should -BeIn 'TestObject1', 'TestObject2';
         }
 
         It 'Json String' {
@@ -326,7 +326,7 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
             $result | Should -Not -BeNullOrEmpty;
             $result.Length | Should -Be 2;
             $result | Should -BeOfType PSRule.Rules.RuleRecord;
-            $result.TargetName | Should -BeIn 'TestObject1', 'TestObject2'
+            $result.TargetName | Should -BeIn 'TestObject1', 'TestObject2';
         }
 
         It 'Json FileInfo' {
@@ -335,7 +335,27 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
             $result | Should -Not -BeNullOrEmpty;
             $result.Length | Should -Be 2;
             $result | Should -BeOfType PSRule.Rules.RuleRecord;
-            $result.TargetName | Should -BeIn 'TestObject1', 'TestObject2'
+            $result.TargetName | Should -BeIn 'TestObject1', 'TestObject2';
+        }
+
+        It 'Markdown String' {
+            $markdown = Get-Content -Path (Join-Path -Path $here -ChildPath 'ObjectFromFile.md') -Raw;
+            $result = @(Invoke-PSRule -Path $ruleFilePath -Name 'WithFormat' -InputObject $markdown -Format Markdown);
+            $result | Should -Not -BeNullOrEmpty;
+            $result.Length | Should -Be 1;
+            $result | Should -BeOfType PSRule.Rules.RuleRecord;
+            $result.TargetName | Should -BeIn 'TestObject1';
+            $result.IsSuccess() | Should -Be $True;
+        }
+
+        It 'Markdown FileInfo' {
+            $file = Get-ChildItem -Path (Join-Path -Path $here -ChildPath 'ObjectFromFile.md') -File;
+            $result = @(Invoke-PSRule -Path $ruleFilePath -Name 'WithFormat' -InputObject $file -Format Markdown);
+            $result | Should -Not -BeNullOrEmpty;
+            $result.Length | Should -Be 1;
+            $result | Should -BeOfType PSRule.Rules.RuleRecord;
+            $result.TargetName | Should -BeIn 'TestObject1';
+            $result.IsSuccess() | Should -Be $True;
         }
     }
 
@@ -346,7 +366,7 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
             $result | Should -Not -BeNullOrEmpty;
             $result.Length | Should -Be 2;
             $result | Should -BeOfType PSRule.Rules.RuleRecord;
-            $result.TargetName | Should -BeIn 'TestObject1', 'TestObject2'
+            $result.TargetName | Should -BeIn 'TestObject1', 'TestObject2';
         }
     }
 


### PR DESCRIPTION
## PR Summary

- Added input format for reading markdown front matter. #301
  - Markdown front matter is deserialized and evaluated as an object.
- Added source note properties to input objects read from disk with `-InputPath`. #302

Fixes #301 
Fixes #302 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/BernieWhite/PSRule/blob/master/CHANGELOG.md) has been updated with change under unreleased section
