### PR TITLE
Remove Hint alias for Recommend #165

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Added input format for reading markdown front matter. [#301](https://github.com/BernieWhite/PSRule/issues/301)
   - Markdown front matter is deserialized and evaluated as an object.
 - Added source note properties to input objects read from disk with `-InputPath`. [#302](https://github.com/BernieWhite/PSRule/issues/302)
+- **Breaking change**: Removed previously deprecated alias `Hint` for `Recommend`. [#165](https://github.com/BernieWhite/PSRule/issues/165)
+  - Use the `Recommend` keyword instead.
 
 ## v0.10.0-B1910025 (pre-release)
 

--- a/docs/keywords/PSRule/en-US/about_PSRule_Keywords.md
+++ b/docs/keywords/PSRule/en-US/about_PSRule_Keywords.md
@@ -337,11 +337,10 @@ None.
 
 ### Recommend
 
-The `Recommend` keyword is used within a `Rule` definition to provide a recommendation to resolve the issue and pass the rule. This may include manual steps to change that state of the object or the desired state accessed by the rule.
+The `Recommend` keyword is used within a `Rule` definition to provide a recommendation to resolve the issue and pass the rule.
+This may include manual steps to change that state of the object or the desired state accessed by the rule.
 
 The recommendation can only be set once per rule. Each object will use the same recommendation.
-
-Previously this keyword was `Hint`. The previous keyword `Hint` is aliased but deprecated.
 
 Syntax:
 

--- a/src/PSRule/Host/Host.cs
+++ b/src/PSRule/Host/Host.cs
@@ -132,7 +132,6 @@ namespace PSRule.Host
         {
             new SessionStateAliasEntry(LanguageKeywords.Rule, "New-RuleDefinition", string.Empty, ScopedItemOptions.ReadOnly),
             new SessionStateAliasEntry(LanguageKeywords.Recommend, "Write-Recommendation", string.Empty, ScopedItemOptions.ReadOnly),
-            new SessionStateAliasEntry("hint", "Write-Recommendation", string.Empty, ScopedItemOptions.ReadOnly),
             new SessionStateAliasEntry(LanguageKeywords.Reason, "Write-Reason", string.Empty, ScopedItemOptions.ReadOnly),
             new SessionStateAliasEntry(LanguageKeywords.Exists, "Assert-Exists", string.Empty, ScopedItemOptions.ReadOnly),
             new SessionStateAliasEntry(LanguageKeywords.Within, "Assert-Within", string.Empty, ScopedItemOptions.ReadOnly),

--- a/src/PSRule/PSRule.psd1
+++ b/src/PSRule/PSRule.psd1
@@ -104,9 +104,7 @@ VariablesToExport = @(
 )
 
 # Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
-AliasesToExport = @(
-    'Hint'
-)
+AliasesToExport = @()
 
 # DSC resources to export from this module
 # DscResourcesToExport = @()

--- a/src/PSRule/PSRule.psm1
+++ b/src/PSRule/PSRule.psm1
@@ -1808,12 +1808,6 @@ function InitEditorServices {
                 'Recommend'
             );
 
-            # Define aliases
-            $Null = New-Alias -Name Hint -Value Recommend -Scope Global -Force;
-            Export-ModuleMember -Alias @(
-                'Hint'
-            );
-
             # Export variables
             Export-ModuleMember -Variable @(
                 'Assert'

--- a/tests/PSRule.Tests/FromFile.Rule.ps1
+++ b/tests/PSRule.Tests/FromFile.Rule.ps1
@@ -185,11 +185,6 @@ Rule 'RecommendTest2' {
     Recommend 'This is a recommendation'
 }
 
-# Synopsis: Test for Recommend keyword alias
-Rule 'HintTest' {
-    Hint 'This is a recommendation'
-}
-
 # Synopsis: Test for Recommend keyword
 Rule 'TestWithSynopsis' {
     $True

--- a/tests/PSRule.Tests/PSRule.PSGallery.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.PSGallery.Tests.ps1
@@ -52,16 +52,6 @@ Describe 'PSRule' -Tag 'PowerShellGallery' {
             $expected | Should -BeIn $filteredCommands.Name;
             $expected | Should -BeIn $result.ExportedFunctions.Keys;
         }
-
-        It 'Exports aliases' {
-            $filteredCommands = @($commands | Where-Object -FilterScript { $_ -is [System.Management.Automation.AliasInfo] });
-            $filteredCommands | Should -Not -BeNullOrEmpty;
-            $expected = @(
-                'Hint'
-            )
-            $expected | Should -BeIn $filteredCommands.Name;
-            $expected | Should -BeIn $result.ExportedAliases.Keys;
-        }
     }
 
     Context 'Static analysis' {

--- a/tests/PSRule.Tests/PSRule.Recommend.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Recommend.Tests.ps1
@@ -28,11 +28,11 @@ Describe 'PSRule -- Recommend keyword' -Tag 'Recommend' {
 
         It 'Sets result properties' {
             $option = @{ 'Execution.InconclusiveWarning' = $False };
-            $result = @($testObject | Invoke-PSRule -Path (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1') -Option $option -Name 'HintTest', 'RecommendTest' -Outcome All -WarningVariable outWarning);
+            $result = @($testObject | Invoke-PSRule -Path (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1') -Option $option -Name 'RecommendTest' -Outcome All -WarningVariable outWarning);
             $warningMessages = @($outWarning);
             $result | Should -Not -BeNullOrEmpty;
-            $result.Length | Should -Be 2;
-            $result.RuleName | Should -BeIn 'HintTest', 'RecommendTest';
+            $result.Length | Should -Be 1;
+            $result.RuleName | Should -BeIn 'RecommendTest';
             $result.Recommendation | Should -BeIn 'This is a recommendation';
             $warningMessages.Length | Should -Be 0;
         }


### PR DESCRIPTION
## PR Summary

- **Breaking change**: Removed previously deprecated alias `Hint` for `Recommend`. #165
  - Use the `Recommend` keyword instead.

Fixes #165 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/BernieWhite/PSRule/blob/master/CHANGELOG.md) has been updated with change under unreleased section
