### PR TITLE
Pre-release v0.10.0-B1910036

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.10.0-B1910036 (pre-release)
+
 - Added dependency `DependsOn` information to results from `Get-PSRule`. [#210](https://github.com/BernieWhite/PSRule/issues/210)
   - To include dependencies that would normally be filtered out use `-IncludeDependencies`.
 - Added input format for reading markdown front matter. [#301](https://github.com/BernieWhite/PSRule/issues/301)


### PR DESCRIPTION
## PR Summary

- Added dependency `DependsOn` information to results from `Get-PSRule`. #210
  - To include dependencies that would normally be filtered out use `-IncludeDependencies`.
- Added input format for reading markdown front matter. #301
  - Markdown front matter is deserialized and evaluated as an object.
- Added source note properties to input objects read from disk with `-InputPath`. #302
- **Breaking change**: Removed previously deprecated alias `Hint` for `Recommend`. #165
  - Use the `Recommend` keyword instead.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
